### PR TITLE
[1.0.0] Add more type info. Add a benchmark system.

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -1,0 +1,155 @@
+name: Perf
+
+on:
+  pull_request:
+    paths:
+      - 'src/**'
+      - 'tests/performance/**'
+      - 'tests/bin/asn1-bench*'
+      - 'composer.json'
+  push:
+    branches:
+      - main
+    paths:
+      - 'src/**'
+      - 'tests/performance/**'
+      - 'tests/bin/asn1-bench*'
+      - 'composer.json'
+  workflow_dispatch:
+
+# Both jobs are advisory-only at this point. We use `continue-on-error: true`
+# so the workflow surfaces the results to the PR / commit without blocking
+# merges. Promote to required checks once the false-positive rate on
+# GitHub-hosted runners is calibrated.
+
+jobs:
+  regression:
+    name: PR performance regression check (HEAD vs merge-base)
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    timeout-minutes: 15
+    env:
+      PAIRS: 5
+      THRESHOLD: 7
+      CONSISTENCY: 80
+    steps:
+      - name: Checkout PR
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.5'
+          extensions: mbstring, gmp, opcache
+          coverage: none
+          tools: composer:2.9
+          ini-values: opcache.enable_cli=1, opcache.jit_buffer_size=128M, opcache.jit=1255, zend.assertions=-1
+
+      - name: Cache composer dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.composer/cache
+          key: composer-${{ runner.os }}-${{ hashFiles('composer.json') }}
+          restore-keys: composer-${{ runner.os }}-
+
+      - name: Install Composer dependencies
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 5
+          max_attempts: 3
+          retry_wait_seconds: 15
+          command: composer install --no-progress --prefer-dist --optimize-autoloader
+
+      - name: Resolve merge-base
+        id: mb
+        run: |
+          MERGE_BASE=$(git merge-base origin/${{ github.base_ref }} HEAD)
+          HEAD_SHA=$(git rev-parse HEAD)
+          echo "merge_base=$MERGE_BASE" >> "$GITHUB_OUTPUT"
+          echo "head_sha=$HEAD_SHA" >> "$GITHUB_OUTPUT"
+          echo "PR HEAD:     $HEAD_SHA"
+          echo "merge-base:  $MERGE_BASE"
+
+      - name: Run baseline pairs (merge-base)
+        run: |
+          mkdir -p /tmp/perf
+          # Restore merge-base sources for the bench, but keep current bench infrastructure.
+          git checkout ${{ steps.mb.outputs.merge_base }} -- src
+          for i in $(seq 1 $PAIRS); do
+            echo "::group::baseline pair $i"
+            composer bench -- --out=/tmp/perf/baseline-$i.json
+            echo "::endgroup::"
+          done
+
+      - name: Run head pairs
+        run: |
+          # Restore PR HEAD sources.
+          git checkout ${{ steps.mb.outputs.head_sha }} -- src
+          for i in $(seq 1 $PAIRS); do
+            echo "::group::head pair $i"
+            composer bench -- --out=/tmp/perf/head-$i.json
+            echo "::endgroup::"
+          done
+
+      - name: Aggregate
+        run: |
+          AGG_ARGS=()
+          for i in $(seq 1 $PAIRS); do
+            AGG_ARGS+=("--baseline=/tmp/perf/baseline-$i.json")
+          done
+          for i in $(seq 1 $PAIRS); do
+            AGG_ARGS+=("--head=/tmp/perf/head-$i.json")
+          done
+          composer bench-aggregate -- "${AGG_ARGS[@]}" --threshold=$THRESHOLD --consistency=$CONSISTENCY | tee /tmp/perf/aggregate.txt
+
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: perf-regression-${{ github.run_number }}
+          path: /tmp/perf/
+
+  floor:
+    name: Absolute floor for performance (vs baseline-floor.json)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.5'
+          extensions: mbstring, gmp, opcache
+          coverage: none
+          tools: composer:2.9
+          ini-values: opcache.enable_cli=1, opcache.jit_buffer_size=128M, opcache.jit=1255, zend.assertions=-1
+
+      - name: Cache composer dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.composer/cache
+          key: composer-${{ runner.os }}-${{ hashFiles('composer.json') }}
+          restore-keys: composer-${{ runner.os }}-
+
+      - name: Install Composer dependencies
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 5
+          max_attempts: 3
+          retry_wait_seconds: 15
+          command: composer install --no-progress --prefer-dist --optimize-autoloader
+
+      - name: Run bench-vs-floor
+        run: composer bench-vs-floor | tee /tmp/floor-result.txt
+
+      - name: Upload artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: perf-floor-${{ github.run_number }}
+          path: /tmp/floor-result.txt

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,5 @@ composer.lock
 composer.phar
 .idea/
 vendor/
-bin/
 .phpunit.result.cache
 .phpunit.cache/

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
     "phpstan/phpstan": "^2.1",
     "phpstan/phpstan-phpunit": "^2.0",
     "phpstan/extension-installer": "^1.4",
+    "symfony/console": "^6.4",
     "symplify/easy-coding-standard": "^9.4",
     "squizlabs/php_codesniffer": "^3.7",
     "slevomat/coding-standard": "^7.2"
@@ -35,7 +36,10 @@
     "psr-4": {"FreeDSx\\Asn1\\": "src/FreeDSx/Asn1"}
   },
   "autoload-dev": {
-    "psr-4": {"Tests\\Unit\\FreeDSx\\Asn1\\": "tests/unit"}
+    "psr-4": {
+      "Tests\\Unit\\FreeDSx\\Asn1\\": "tests/unit",
+      "Tests\\Performance\\FreeDSx\\Asn1\\": "tests/performance"
+    }
   },
   "scripts": {
     "test": [
@@ -56,6 +60,18 @@
     "cs-fix": [
       "phpcbf --standard=ruleset.xml --extensions=php --tab-width=4 -sp src",
       "ecs --fix"
+    ],
+    "bench": [
+      "@php -d opcache.enable_cli=1 -d opcache.jit_buffer_size=128M -d opcache.jit=1255 -d xdebug.mode=off -d zend.assertions=-1 tests/bin/asn1-bench.php"
+    ],
+    "bench-compare": [
+      "@php tests/bin/asn1-bench-compare.php"
+    ],
+    "bench-aggregate": [
+      "@php tests/bin/asn1-bench-aggregate.php"
+    ],
+    "bench-vs-baseline": [
+      "tests/bin/bench-vs-baseline.sh"
     ]
   },
   "config": {

--- a/composer.json
+++ b/composer.json
@@ -72,6 +72,12 @@
     ],
     "bench-vs-baseline": [
       "tests/bin/bench-vs-baseline.sh"
+    ],
+    "bench-vs-floor": [
+      "@php -d opcache.enable_cli=1 -d opcache.jit_buffer_size=128M -d opcache.jit=1255 -d xdebug.mode=off -d zend.assertions=-1 tests/bin/asn1-bench-floor.php"
+    ],
+    "bench-update-floor": [
+      "@php -d opcache.enable_cli=1 -d opcache.jit_buffer_size=128M -d opcache.jit=1255 -d xdebug.mode=off -d zend.assertions=-1 tests/bin/asn1-bench-update-floor.php"
     ]
   },
   "config": {

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -3,12 +3,14 @@ parameters:
     paths:
         - %currentWorkingDirectory%/src
     treatPhpDocTypesAsCertain: false
-    reportUnmatchedIgnoredErrors: false
+    reportUnmatchedIgnoredErrors: true
     ignoreErrors:
         - '#Unsafe usage of new static#'
         -
             identifier: varTag.nativeType
             path: %currentWorkingDirectory%/src/FreeDSx/Asn1/Encoder/BerEncoder.php
         -
-            identifier: property.phpDocType
-            path: %currentWorkingDirectory%/src/FreeDSx/Asn1/Type/AbstractTimeType.php
+            # AbstractType uses covariant T for subclass value narrowing
+            # $value is read+written but is effectively write-once.
+            identifier: generics.variance
+            path: %currentWorkingDirectory%/src/FreeDSx/Asn1/Type/AbstractType.php

--- a/phpstan.tests.neon
+++ b/phpstan.tests.neon
@@ -2,7 +2,8 @@ parameters:
     treatPhpDocTypesAsCertain: false
     level: 9
     paths:
-        - %currentWorkingDirectory%/tests
+        - %currentWorkingDirectory%/tests/unit
+        - %currentWorkingDirectory%/tests/performance
     ignoreErrors:
         -
             message: '#expects string, string\|false given\.#'

--- a/src/FreeDSx/Asn1/Encoder/BerEncoder.php
+++ b/src/FreeDSx/Asn1/Encoder/BerEncoder.php
@@ -93,27 +93,20 @@ class BerEncoder implements EncoderInterface
     protected const MAX_SECOND_COMPONENT = PHP_INT_MAX - 80;
 
     /**
-     * @var array
+     * @var array<int, array<int, int>> Tag class => (tag number => universal tag type).
      */
-    protected $tagMap = [
+    protected array $tagMap = [
         AbstractType::TAG_CLASS_APPLICATION => [],
         AbstractType::TAG_CLASS_CONTEXT_SPECIFIC => [],
         AbstractType::TAG_CLASS_PRIVATE => [],
     ];
 
-    protected $tmpTagMap = [];
-
     /**
-     * @var array
+     * @var array<int, array<int, int>> Tag class => (tag number => universal tag type).
      */
-    protected $options = [
-        'bitstring_padding' => '0',
-    ];
+    protected array $tmpTagMap = [];
 
-    /**
-     * @var bool
-     */
-    protected $isGmpAvailable;
+    protected bool $isGmpAvailable;
 
     /**
      * @var int
@@ -135,20 +128,18 @@ class BerEncoder implements EncoderInterface
      */
     protected $binary;
 
-    /**
-     * @param array $options
-     */
-    public function __construct(array $options = [])
+    public function __construct(protected EncoderOptions $options = new EncoderOptions())
     {
         $this->isGmpAvailable = extension_loaded('gmp');
-        $this->setOptions($options);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function decode($binary, array $tagMap = []): AbstractType
-    {
+    public function decode(
+        string $binary,
+        array $tagMap = []
+    ): AbstractType {
         $this->startEncoding($binary, $tagMap);
         if ($this->maxLen === 0) {
             throw new InvalidArgumentException('The data to decode cannot be empty.');
@@ -164,8 +155,11 @@ class BerEncoder implements EncoderInterface
     /**
      * {@inheritdoc}
      */
-    public function complete(IncompleteType $type, int $tagType, array $tagMap = []): AbstractType
-    {
+    public function complete(
+        IncompleteType $type,
+        int $tagType,
+        array $tagMap = [],
+    ): AbstractType {
         $lastPos = $this->lastPos;
         $this->startEncoding($type->getValue(), $tagMap);
         $newType = $this->decodeBytes(false, $tagType, $this->maxLen, $type->getIsConstructed(), AbstractType::TAG_CLASS_UNIVERSAL);
@@ -251,12 +245,14 @@ class BerEncoder implements EncoderInterface
     /**
      * Map universal types to specific tag class values when decoding.
      *
-     * @param int $class
-     * @param array $map
+     * @param array<int, int> $map Tag number => universal tag type.
+     *
      * @return $this
      */
-    public function setTagMap(int $class, array $map)
-    {
+    public function setTagMap(
+        int $class,
+        array $map,
+    ): self {
         if (isset($this->tagMap[$class])) {
             $this->tagMap[$class] = $map;
         }
@@ -266,10 +262,8 @@ class BerEncoder implements EncoderInterface
 
     /**
      * Get the options for the encoder.
-     *
-     * @return array
      */
-    public function getOptions(): array
+    public function getOptions(): EncoderOptions
     {
         return $this->options;
     }
@@ -277,14 +271,11 @@ class BerEncoder implements EncoderInterface
     /**
      * Set the options for the encoder.
      *
-     * @param array $options
      * @return $this
      */
-    public function setOptions(array $options)
+    public function setOptions(EncoderOptions $options): self
     {
-        if (isset($options['bitstring_padding']) && is_string($options['bitstring_padding'])) {
-            $this->options['bitstring_padding'] = $options['bitstring_padding'];
-        }
+        $this->options = $options;
 
         return $this;
     }
@@ -297,8 +288,13 @@ class BerEncoder implements EncoderInterface
         return $this->lastPos;
     }
 
-    protected function startEncoding(string $binary, array $tagMap): void
-    {
+    /**
+     * @param array<int, array<int, int>> $tagMap Tag class => (tag number => universal tag type).
+     */
+    protected function startEncoding(
+        string $binary,
+        array $tagMap,
+    ): void {
         $this->tmpTagMap = $tagMap + $this->tagMap;
         $this->binary = $binary;
         $this->lastPos = null;
@@ -666,7 +662,11 @@ class BerEncoder implements EncoderInterface
         $unused = 0;
         if ($length % 8) {
             $unused = 8 - ($length % 8);
-            $data = str_pad($data, $length + $unused, $this->options['bitstring_padding']);
+            $data = str_pad(
+                $data,
+                $length + $unused,
+                $this->options->bitstringPadding,
+            );
             $length = strlen($data);
         }
 

--- a/src/FreeDSx/Asn1/Encoder/CerDerTrait.php
+++ b/src/FreeDSx/Asn1/Encoder/CerDerTrait.php
@@ -12,7 +12,6 @@ namespace FreeDSx\Asn1\Encoder;
 
 use FreeDSx\Asn1\Exception\EncoderException;
 use FreeDSx\Asn1\Type\AbstractTimeType;
-use FreeDSx\Asn1\Type\AbstractType;
 use FreeDSx\Asn1\Type\SetOfType;
 use function count;
 use function end;
@@ -23,6 +22,7 @@ use function strcmp;
 use function strlen;
 use function usort;
 
+
 /**
  * Common restrictions on CER and DER encoding.
  *
@@ -31,9 +31,6 @@ use function usort;
 trait CerDerTrait
 {
     /**
-     * @param int $length
-     * @param int $unused
-     * @return string
      * @throws EncoderException
      */
     protected function binaryToBitString(int $length, int $unused): string
@@ -49,7 +46,6 @@ trait CerDerTrait
     }
 
     /**
-     * @return bool
      * @throws EncoderException
      */
     protected function decodeBoolean(): bool
@@ -65,8 +61,10 @@ trait CerDerTrait
      * {@inheritdoc}
      * @throws EncoderException
      */
-    protected function encodeTime(AbstractTimeType $type, string $format)
-    {
+    protected function encodeTime(
+        AbstractTimeType $type,
+        string $format
+    ): string {
         $this->validateTimeType($type);
 
         return parent::encodeTime($type, $format);
@@ -74,10 +72,16 @@ trait CerDerTrait
 
     /**
      * {@inheritdoc}
+     *
+     * @param array<int, string> $matches
+     * @param array<string, int> $matchMap
+     *
      * @throws EncoderException
      */
-    protected function validateDateFormat(array $matches, array $matchMap)
-    {
+    protected function validateDateFormat(
+        array $matches,
+        array $matchMap,
+    ): void {
         if (isset($matchMap['fractions']) && isset($matches[$matchMap['fractions']]) && $matches[$matchMap['fractions']] !== '') {
             if ($matches[$matchMap['fractions']][-1] === '0') {
                 throw new EncoderException('Trailing zeros must be omitted from Generalized Time types, but it is not.');
@@ -86,10 +90,9 @@ trait CerDerTrait
     }
 
     /**
-     * @param AbstractTimeType $type
      * @throws EncoderException
      */
-    protected function validateTimeType(AbstractTimeType $type)
+    protected function validateTimeType(AbstractTimeType $type): void
     {
         if ($type->getTimeZoneFormat() !== AbstractTimeType::TZ_UTC) {
             throw new EncoderException(sprintf(
@@ -128,14 +131,13 @@ trait CerDerTrait
      * come by in ASN.1 libraries for some reason.
      *
      * @todo Is this assumed ordering correct? Confirmation needed. This could probably be simplified too.
-     * @param SetOfType $setOf
-     * @return string
      */
-    protected function encodeSetOf(SetOfType $setOf)
+    protected function encodeSetOf(SetOfType $setOf): string
     {
         if (count($setOf->getChildren()) === 0) {
             return '';
         }
+        /** @var list<array{original: string, length: int}> $children */
         $children = [];
 
         # Encode each child and record the length, we need it later
@@ -147,14 +149,13 @@ trait CerDerTrait
 
         # Sort the encoded types by length first to determine the padding needed.
         usort($children, function ($a, $b) {
-            /* @var AbstractType $a
-             * @var AbstractType $b */
             return $a['length'] < $b['length'] ? -1 : 1;
         });
 
         # Get the last child (ie. the longest), and put the array back to normal.
+        /** @var array{original: string, length: int} $child */
         $child = end($children);
-        $padding = $child ['length'];
+        $padding = $child['length'];
         reset($children);
 
         # Sort by padding the items and comparing them.

--- a/src/FreeDSx/Asn1/Encoder/DerEncoder.php
+++ b/src/FreeDSx/Asn1/Encoder/DerEncoder.php
@@ -29,15 +29,10 @@ class DerEncoder extends BerEncoder
     use CerDerTrait,
         SetTrait;
 
-    /**
-     * @param array $options
-     */
-    public function __construct(array $options = [])
+    public function __construct(EncoderOptions $options = new EncoderOptions())
     {
         parent::__construct($options);
-        $this->setOptions([
-            'bitstring_padding' => '0',
-        ]);
+        $this->setOptions(new EncoderOptions(bitstringPadding: '0'));
     }
 
     public function encode(AbstractType $type): string

--- a/src/FreeDSx/Asn1/Encoder/EncoderInterface.php
+++ b/src/FreeDSx/Asn1/Encoder/EncoderInterface.php
@@ -34,10 +34,8 @@ interface EncoderInterface
     /**
      * Decodes (completes) an incomplete type to a specific universal tag type object.
      *
-     * @param IncompleteType $type
-     * @param int $tagType
-     * @param array $tagMap
-     * @return AbstractType
+     * @param array<int, array<int, int>> $tagMap Tag class => (tag number => universal tag type).
+     *
      * @throws EncoderException
      */
     public function complete(IncompleteType $type, int $tagType, array $tagMap = []): AbstractType;
@@ -45,13 +43,15 @@ interface EncoderInterface
     /**
      * Decode binary data to its ASN1 object representation.
      *
-     * @param string $binary
-     * @param array $tagMap
-     * @return AbstractType
+     * @param array<int, array<int, int>> $tagMap Tag class => (tag number => universal tag type).
+     *
      * @throws EncoderException
      * @throws PartialPduException
      */
-    public function decode($binary, array $tagMap = []): AbstractType;
+    public function decode(
+        string $binary,
+        array $tagMap = []
+    ): AbstractType;
 
     /**
      * Get the last position of the binary byte stream after a decode operation.

--- a/src/FreeDSx/Asn1/Encoder/EncoderOptions.php
+++ b/src/FreeDSx/Asn1/Encoder/EncoderOptions.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx ASN1 package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Asn1\Encoder;
+
+/**
+ * Options shared by ASN.1 encoders.
+ */
+final readonly class EncoderOptions
+{
+    public function __construct(
+        public string $bitstringPadding = '0',
+    ) {
+    }
+}

--- a/src/FreeDSx/Asn1/Encoders.php
+++ b/src/FreeDSx/Asn1/Encoders.php
@@ -11,6 +11,7 @@
 namespace FreeDSx\Asn1;
 
 use FreeDSx\Asn1\Encoder\BerEncoder;
+use FreeDSx\Asn1\Encoder\EncoderOptions;
 use FreeDSx\Asn1\Encoder\DerEncoder;
 
 /**
@@ -20,20 +21,12 @@ use FreeDSx\Asn1\Encoder\DerEncoder;
  */
 class Encoders
 {
-    /**
-     * @param array $options
-     * @return BerEncoder
-     */
-    public static function ber(array $options = []): BerEncoder
+    public static function ber(EncoderOptions $options = new EncoderOptions()): BerEncoder
     {
         return new BerEncoder($options);
     }
 
-    /**
-     * @param array $options
-     * @return DerEncoder
-     */
-    public static function der(array $options = []): DerEncoder
+    public static function der(EncoderOptions $options = new EncoderOptions()): DerEncoder
     {
         return new DerEncoder($options);
     }

--- a/src/FreeDSx/Asn1/Type/AbstractStringType.php
+++ b/src/FreeDSx/Asn1/Type/AbstractStringType.php
@@ -13,6 +13,8 @@ namespace FreeDSx\Asn1\Type;
 /**
  * Represents the various ASN1 string types.
  *
+ * @extends AbstractType<string>
+ *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
 abstract class AbstractStringType extends AbstractType
@@ -22,55 +24,47 @@ abstract class AbstractStringType extends AbstractType
      */
     protected $isCharRestricted = false;
 
-    public function __construct($value = '')
+    public function __construct(string $value = '')
     {
         parent::__construct($value);
     }
 
-    /**
-     * @return string
-     */
-    public function getValue()
+    public function getValue(): string
     {
         return $this->value;
     }
 
     /**
-     * @param string $value
      * @return $this
      */
-    public function setValue($value)
+    public function setValue(string $value)
     {
         $this->value = $value;
 
         return $this;
     }
 
-    /**
-     * @return string
-     */
-    public function __toString()
+    public function __toString(): string
     {
-        return (string) $this->value;
+        return $this->getValue();
     }
 
-    /**
-     * @return bool
-     */
-    public function isCharacterRestricted()
+    public function isCharacterRestricted(): bool
     {
         return $this->isCharRestricted;
     }
 
     /**
-     * @param string|int $tagNumber
-     * @param int $class
-     * @param bool $isConstructed
-     * @param string $value
-     * @return AbstractStringType
+     * @param int|string $tagNumber
+     *
+     * @return static
      */
-    public static function withTag($tagNumber, int $class, bool $isConstructed, $value = '')
-    {
+    public static function withTag(
+        $tagNumber,
+        int $class,
+        bool $isConstructed,
+        string $value = '',
+    ) {
         $type = new static($value);
         $type->taggingClass = $class;
         $type->tagNumber = $tagNumber;

--- a/src/FreeDSx/Asn1/Type/AbstractTimeType.php
+++ b/src/FreeDSx/Asn1/Type/AbstractTimeType.php
@@ -57,44 +57,41 @@ class AbstractTimeType extends AbstractType
     public const TZ_DIFF = 'diff';
 
     /**
-     * @var string[] Valid datetime formats.
+     * @var array<int, string> Valid datetime formats.
      */
     protected $validDateFormats = [];
 
     /**
-     * @var string[] Valid timezone formats
+     * @var array<int, string> Valid timezone formats
      */
     protected $validTzFormats = [];
 
     /**
      * @var string
      */
-    protected $tzFormat;
+    protected $tzFormat = self::TZ_UTC;
 
     /**
      * @var string
      */
-    protected $dateFormat;
+    protected $dateFormat = self::FORMAT_SECONDS;
 
     /**
-     * @var DateTimeInterface|null
-     */
-    protected $value;
-
-    /**
-     * @param DateTimeInterface|null $dateTime
      * @param string $dateFormat Represents the furthest datetime element to represent in the datetime object.
      * @param string $tzFormat Represents the format of the timezone.
      */
-    public function __construct(?DateTimeInterface $dateTime, string $dateFormat, string $tzFormat)
-    {
+    public function __construct(
+        ?DateTimeInterface $dateTime,
+        string $dateFormat,
+        string $tzFormat
+    ) {
         $this->setDateTimeFormat($dateFormat);
         $this->setTimeZoneFormat($tzFormat);
-        parent::__construct($dateTime ?? new DateTime());
+        parent::__construct(null);
+        $this->value = $dateTime ?? new DateTime();
     }
 
     /**
-     * @param DateTimeInterface $dateTime
      * @return $this
      */
     public function setValue(DateTimeInterface $dateTime)
@@ -104,24 +101,17 @@ class AbstractTimeType extends AbstractType
         return $this;
     }
 
-    /**
-     * @return DateTimeInterface
-     */
     public function getValue(): DateTimeInterface
     {
         return $this->value;
     }
 
-    /**
-     * @return string
-     */
     public function getTimeZoneFormat(): string
     {
         return $this->tzFormat;
     }
 
     /**
-     * @param string $tzFormat
      * @return $this
      */
     public function setTimeZoneFormat(string $tzFormat)
@@ -138,16 +128,12 @@ class AbstractTimeType extends AbstractType
         return $this;
     }
 
-    /**
-     * @return string
-     */
     public function getDateTimeFormat(): string
     {
         return $this->dateFormat;
     }
 
     /**
-     * @param string $dateFormat
      * @return $this
      */
     public function setDateTimeFormat(string $dateFormat)
@@ -165,16 +151,18 @@ class AbstractTimeType extends AbstractType
     }
 
     /**
-     * @param string|int $tagNumber
-     * @param int $class
-     * @param bool $isConstructed
-     * @param DateTimeInterface|null $dateTime
-     * @param string $dateFormat
-     * @param string $tzFormat
-     * @return AbstractTimeType
+     * @param int|string $tagNumber
+     *
+     * @return static
      */
-    public static function withTag($tagNumber, int $class, bool $isConstructed, ?DateTimeInterface $dateTime, string $dateFormat, string $tzFormat)
-    {
+    public static function withTag(
+        $tagNumber,
+        int $class,
+        bool $isConstructed,
+        ?DateTimeInterface $dateTime,
+        string $dateFormat,
+        string $tzFormat,
+    ) {
         $type = new static($dateTime, $dateFormat, $tzFormat);
         $type->tagNumber = $tagNumber;
         $type->taggingClass = $class;

--- a/src/FreeDSx/Asn1/Type/AbstractType.php
+++ b/src/FreeDSx/Asn1/Type/AbstractType.php
@@ -20,6 +20,11 @@ use function count;
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
+/**
+ * @template-covariant T
+ *
+ * @implements IteratorAggregate<int, AbstractType<mixed>>
+ */
 abstract class AbstractType implements Countable, IteratorAggregate
 {
     public const TAG_CLASS_UNIVERSAL = 0x00;
@@ -92,12 +97,12 @@ abstract class AbstractType implements Countable, IteratorAggregate
     public const CONSTRUCTED_TYPE = 0x20;
 
     /**
-     * @var scalar|null
+     * @var T
      */
     protected $value;
 
     /**
-     * @var null|int|string
+     * @var int|string|null
      */
     protected $tagNumber;
 
@@ -112,28 +117,24 @@ abstract class AbstractType implements Countable, IteratorAggregate
     protected $isConstructed = false;
 
     /**
-     * @var AbstractType[]
+     * @var array<AbstractType>
      */
     protected $children = [];
 
     /**
-     * @param mixed $value
+     * @param T $value
      */
     public function __construct($value)
     {
         $this->value = $value;
     }
 
-    /**
-     * @return bool
-     */
     public function getIsConstructed(): bool
     {
         return $this->isConstructed;
     }
 
     /**
-     * @param bool $isConstructed
      * @return $this
      */
     public function setIsConstructed(bool $isConstructed)
@@ -144,7 +145,6 @@ abstract class AbstractType implements Countable, IteratorAggregate
     }
 
     /**
-     * @param int $taggingClass
      * @return $this
      */
     public function setTagClass(int $taggingClass)
@@ -154,16 +154,13 @@ abstract class AbstractType implements Countable, IteratorAggregate
         return $this;
     }
 
-    /**
-     * @return int
-     */
     public function getTagClass(): int
     {
         return $this->taggingClass;
     }
 
     /**
-     * @return int|null|string
+     * @return int|string|null
      */
     public function getTagNumber()
     {
@@ -171,7 +168,8 @@ abstract class AbstractType implements Countable, IteratorAggregate
     }
 
     /**
-     * @param int|null|string $int
+     * @param int|string|null $int
+     *
      * @return $this
      */
     public function setTagNumber($int)
@@ -181,22 +179,22 @@ abstract class AbstractType implements Countable, IteratorAggregate
         return $this;
     }
 
+    /**
+     * @return T
+     */
     public function getValue()
     {
         return $this->value;
     }
 
-    /**
-     * @param int $index
-     * @return bool
-     */
-    public function hasChild(int $index)
+    public function hasChild(int $index): bool
     {
         return isset($this->children[$index]);
     }
 
     /**
      * @param AbstractType ...$types
+     *
      * @return $this
      */
     public function setChildren(...$types)
@@ -207,17 +205,13 @@ abstract class AbstractType implements Countable, IteratorAggregate
     }
 
     /**
-     * @return AbstractType[]
+     * @return array<AbstractType>
      */
     public function getChildren(): array
     {
         return $this->children;
     }
 
-    /**
-     * @param int $index
-     * @return null|AbstractType
-     */
     public function getChild(int $index): ?AbstractType
     {
         return $this->children[$index] ?? null;
@@ -225,6 +219,7 @@ abstract class AbstractType implements Countable, IteratorAggregate
 
     /**
      * @param AbstractType ...$types
+     *
      * @return $this
      */
     public function addChild(...$types)
@@ -236,16 +231,13 @@ abstract class AbstractType implements Countable, IteratorAggregate
         return $this;
     }
 
-    /**
-     * @return int
-     */
     public function count(): int
     {
         return count($this->children);
     }
 
     /**
-     * @return ArrayIterator<AbstractType>
+     * @return ArrayIterator<int, AbstractType>
      */
     public function getIterator(): ArrayIterator
     {

--- a/src/FreeDSx/Asn1/Type/BigIntTrait.php
+++ b/src/FreeDSx/Asn1/Type/BigIntTrait.php
@@ -22,8 +22,6 @@ trait BigIntTrait
 {
     /**
      * Whether or not the contained value is larger than the PHP_INT_MAX value (represented as a string value).
-     *
-     * @return bool
      */
     public function isBigInt(): bool
     {
@@ -31,6 +29,6 @@ trait BigIntTrait
             return false;
         }
 
-        return is_float($this->value + 0);
+        return is_float($this->value + 0); // @phpstan-ignore binaryOp.invalid (numeric string addition is intentional)
     }
 }

--- a/src/FreeDSx/Asn1/Type/BitStringType.php
+++ b/src/FreeDSx/Asn1/Type/BitStringType.php
@@ -13,31 +13,26 @@ namespace FreeDSx\Asn1\Type;
 /**
  * Represents a bit string type.
  *
+ * @extends AbstractType<string>
+ *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
 class BitStringType extends AbstractType
 {
     protected $tagNumber = self::TAG_TYPE_BIT_STRING;
 
-    /**
-     * @param string $value
-     */
     public function __construct(string $value = '')
     {
         parent::__construct($value);
     }
 
-    /**
-     * @return string
-     */
-    public function getValue()
+    public function getValue(): string
     {
         return $this->value;
     }
 
     /**
-     * @param string $value
-     * @return BitStringType
+     * @return $this
      */
     public function setValue(string $value)
     {
@@ -48,25 +43,24 @@ class BitStringType extends AbstractType
 
     /**
      * Get the integer representation of the bit string.
-     *
-     * @return int
      */
     public function toInteger(): int
     {
-        return hexdec(bin2hex(rtrim($this->toBinary(), "\x00")));
+        return (int) hexdec(bin2hex(rtrim(
+            $this->toBinary(),
+            "\x00",
+        )));
     }
 
     /**
      * Get the packed binary representation.
-     *
-     * @return string
      */
-    public function toBinary()
+    public function toBinary(): string
     {
         $bytes = '';
 
-        foreach (str_split($this->value, 8) as $piece) {
-            $bytes .= chr(bindec($piece));
+        foreach (str_split($this->getValue(), 8) as $piece) {
+            $bytes .= chr(((int) bindec($piece)) & 0xff);
         }
 
         return $bytes;
@@ -74,13 +68,11 @@ class BitStringType extends AbstractType
 
     /**
      * Construct the bit string from a binary string value.
-     *
-     * @param string $bytes
-     * @param int|null $minLength
-     * @return BitStringType
      */
-    public static function fromBinary($bytes, ?int $minLength = null)
-    {
+    public static function fromBinary(
+        string $bytes,
+        ?int $minLength = null,
+    ): self {
         $bitstring = '';
 
         $length = strlen($bytes);
@@ -96,13 +88,11 @@ class BitStringType extends AbstractType
 
     /**
      * Construct the bit string from an integer.
-     *
-     * @param int $int
-     * @param int|null $minLength
-     * @return BitStringType
      */
-    public static function fromInteger(int $int, ?int $minLength = null)
-    {
+    public static function fromInteger(
+        int $int,
+        ?int $minLength = null
+    ): self {
         $pieces = str_split(decbin($int), 8);
         $num = count($pieces);
 
@@ -121,14 +111,14 @@ class BitStringType extends AbstractType
     }
 
     /**
-     * @param string|int $tagNumber
-     * @param int $class
-     * @param bool $isConstructed
-     * @param string $value
-     * @return AbstractType
+     * @param int|string $tagNumber
      */
-    public static function withTag($tagNumber, int $class, bool $isConstructed, string $value = '')
-    {
+    public static function withTag(
+        $tagNumber,
+        int $class,
+        bool $isConstructed,
+        string $value = ''
+    ): self {
         $type = new self($value);
         $type->taggingClass = $class;
         $type->tagNumber = $tagNumber;

--- a/src/FreeDSx/Asn1/Type/BooleanType.php
+++ b/src/FreeDSx/Asn1/Type/BooleanType.php
@@ -13,22 +13,25 @@ namespace FreeDSx\Asn1\Type;
 /**
  * Represents an ASN1 boolean type.
  *
+ * @extends AbstractType<bool>
+ *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
 class BooleanType extends AbstractType
 {
     protected $tagNumber = self::TAG_TYPE_BOOLEAN;
 
-    /**
-     * @param bool $value
-     */
     public function __construct(bool $value)
     {
         parent::__construct($value);
     }
 
+    public function getValue(): bool
+    {
+        return $this->value;
+    }
+
     /**
-     * @param bool $value
      * @return $this
      */
     public function setValue(bool $value)
@@ -39,12 +42,13 @@ class BooleanType extends AbstractType
     }
 
     /**
-     * @param string|int $tagNumber
-     * @param int $class
-     * @param bool $value
-     * @return BooleanType
+     * @param int|string $tagNumber
      */
-    public static function withTag($tagNumber, int $class, bool $value)
+    public static function withTag(
+        $tagNumber,
+        int $class,
+        bool $value
+    ): self
     {
         $type = new self($value);
         $type->taggingClass = $class;

--- a/src/FreeDSx/Asn1/Type/EnumeratedType.php
+++ b/src/FreeDSx/Asn1/Type/EnumeratedType.php
@@ -13,6 +13,8 @@ namespace FreeDSx\Asn1\Type;
 /**
  * Represents an ASN1 enumerated type.
  *
+ * @extends AbstractType<int|string>
+ *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
 class EnumeratedType extends AbstractType
@@ -22,7 +24,15 @@ class EnumeratedType extends AbstractType
     protected $tagNumber = self::TAG_TYPE_ENUMERATED;
 
     /**
-     * @param string|int $value
+     * @return int|string
+     */
+    public function getValue()
+    {
+        return $this->value;
+    }
+
+    /**
+     * @param int|string $value
      * @return $this
      */
     public function setValue($value)
@@ -33,12 +43,14 @@ class EnumeratedType extends AbstractType
     }
 
     /**
-     * @param string|int $tagNumber
-     * @param int $class
-     * @param string|int $value
-     * @return EnumeratedType
+     * @param int|string $tagNumber
+     * @param int|string $value
      */
-    public static function withTag($tagNumber, int $class, $value)
+    public static function withTag(
+        $tagNumber,
+        int $class,
+        $value
+    ): self
     {
         $type = new self($value);
         $type->tagNumber = $tagNumber;

--- a/src/FreeDSx/Asn1/Type/IncompleteType.php
+++ b/src/FreeDSx/Asn1/Type/IncompleteType.php
@@ -14,21 +14,26 @@ namespace FreeDSx\Asn1\Type;
  * Represents an incomplete ASN1 type where there was not enough information available to decode it. The value contains
  * the complete binary value.
  *
+ * @extends AbstractType<string>
+ *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
 class IncompleteType extends AbstractType
 {
-    /**
-     * @param string $value
-     * @param int|string|null $tagNumber Numeric strings are accepted for big-int tag numbers.
-     * @param int $class
-     * @param bool $isConstructed
-     */
-    public function __construct($value, $tagNumber = null, int $class = AbstractType::TAG_CLASS_UNIVERSAL, bool $isConstructed = false)
-    {
+    public function __construct(
+        string $value,
+        int|string|null $tagNumber = null,
+        int $class = AbstractType::TAG_CLASS_UNIVERSAL,
+        bool $isConstructed = false,
+    ) {
         $this->tagNumber = $tagNumber;
         $this->taggingClass = $class;
         $this->isConstructed = $isConstructed;
         parent::__construct($value);
+    }
+
+    public function getValue(): string
+    {
+        return $this->value;
     }
 }

--- a/src/FreeDSx/Asn1/Type/IntegerType.php
+++ b/src/FreeDSx/Asn1/Type/IntegerType.php
@@ -13,6 +13,8 @@ namespace FreeDSx\Asn1\Type;
 /**
  * Represents an ASN1 integer type.
  *
+ * @extends AbstractType<int|string>
+ *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
 class IntegerType extends AbstractType
@@ -20,6 +22,14 @@ class IntegerType extends AbstractType
     use BigIntTrait;
 
     protected $tagNumber = self::TAG_TYPE_INTEGER;
+
+    /**
+     * @return int|string
+     */
+    public function getValue()
+    {
+        return $this->value;
+    }
 
     /**
      * @param int|string $value
@@ -33,12 +43,14 @@ class IntegerType extends AbstractType
     }
 
     /**
-     * @param string|int $tagNumber
-     * @param int $class
-     * @param string|int $value
-     * @return IntegerType
+     * @param int|string $tagNumber
+     * @param int|string $value
      */
-    public static function withTag($tagNumber, int $class, $value)
+    public static function withTag(
+        $tagNumber,
+        int $class,
+        $value
+    ): self
     {
         $type = new self($value);
         $type->tagNumber = $tagNumber;

--- a/src/FreeDSx/Asn1/Type/NullType.php
+++ b/src/FreeDSx/Asn1/Type/NullType.php
@@ -13,6 +13,8 @@ namespace FreeDSx\Asn1\Type;
 /**
  * Represents an ASN1 null type.
  *
+ * @extends AbstractType<null>
+ *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
 class NullType extends AbstractType
@@ -24,7 +26,18 @@ class NullType extends AbstractType
         parent::__construct(null);
     }
 
-    public static function withTag($tagNumber, $class)
+    public function getValue(): null
+    {
+        return null;
+    }
+
+    /**
+     * @param int|string $tagNumber
+     */
+    public static function withTag(
+        $tagNumber,
+        int $class
+    ): self
     {
         $type = new self();
         $type->tagNumber = $tagNumber;

--- a/src/FreeDSx/Asn1/Type/OidType.php
+++ b/src/FreeDSx/Asn1/Type/OidType.php
@@ -13,22 +13,25 @@ namespace FreeDSx\Asn1\Type;
 /**
  * Represents an OID ASN1 type.
  *
+ * @extends AbstractType<string>
+ *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
 class OidType extends AbstractType
 {
     protected $tagNumber = self::TAG_TYPE_OID;
 
-    /**
-     * @param string $value
-     */
     public function __construct(string $value)
     {
         parent::__construct($value);
     }
 
+    public function getValue(): string
+    {
+        return $this->value;
+    }
+
     /**
-     * @param string $oid
      * @return $this
      */
     public function setValue(string $oid)
@@ -40,11 +43,12 @@ class OidType extends AbstractType
 
     /**
      * @param int|string $tagNumber
-     * @param int $class
-     * @param string $value
-     * @return OidType
      */
-    public static function withTag($tagNumber, int $class, string $value)
+    public static function withTag(
+        $tagNumber,
+        int $class,
+        string $value
+    ): self
     {
         $type = new self($value);
         $type->tagNumber = $tagNumber;

--- a/src/FreeDSx/Asn1/Type/RealType.php
+++ b/src/FreeDSx/Asn1/Type/RealType.php
@@ -13,23 +13,21 @@ namespace FreeDSx\Asn1\Type;
 /**
  * Represents an ASN.1 Real type.
  *
+ * @extends AbstractType<float>
+ *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
 class RealType extends AbstractType
 {
     protected $tagNumber = self::TAG_TYPE_REAL;
 
-    /**
-     * @param float $value
-     */
     public function __construct(float $value)
     {
         parent::__construct($value);
     }
 
     /**
-     * @param float $value
-     * @return RealType
+     * @return $this
      */
     public function setValue(float $value)
     {
@@ -38,21 +36,19 @@ class RealType extends AbstractType
         return $this;
     }
 
-    /**
-     * @return float
-     */
     public function getValue(): float
     {
         return $this->value;
     }
 
     /**
-     * @param string|int $tagNumber
-     * @param int $class
-     * @param float $value
-     * @return RealType
+     * @param int|string $tagNumber
      */
-    public static function withTag($tagNumber, int $class, float $value)
+    public static function withTag(
+        $tagNumber,
+        int $class,
+        float $value
+    ): self
     {
         $type = new self($value);
         $type->tagNumber = $tagNumber;

--- a/src/FreeDSx/Asn1/Type/RelativeOidType.php
+++ b/src/FreeDSx/Asn1/Type/RelativeOidType.php
@@ -13,22 +13,20 @@ namespace FreeDSx\Asn1\Type;
 /**
  * Represents a Relative OID type.
  *
+ * @extends AbstractType<string>
+ *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
 class RelativeOidType extends AbstractType
 {
     protected $tagNumber = self::TAG_TYPE_RELATIVE_OID;
 
-    /**
-     * @param string $value
-     */
     public function __construct(string $value)
     {
         parent::__construct($value);
     }
 
     /**
-     * @param string $relativeOid
      * @return $this
      */
     public function setValue(string $relativeOid)
@@ -38,29 +36,24 @@ class RelativeOidType extends AbstractType
         return $this;
     }
 
-    /**
-     * @return string
-     */
     public function getValue(): string
     {
         return $this->value;
     }
 
-    /**
-     * @return string
-     */
-    public function __toString()
+    public function __toString(): string
     {
-        return (string) $this->value;
+        return $this->getValue();
     }
 
     /**
-     * @param string|int $tagNumber
-     * @param int $class
-     * @param string $value
-     * @return RelativeOidType
+     * @param int|string $tagNumber
      */
-    public static function withTag($tagNumber, int $class, string $value)
+    public static function withTag(
+        $tagNumber,
+        int $class,
+        string $value
+    ): self
     {
         $type = new self($value);
         $type->tagNumber = $tagNumber;

--- a/src/FreeDSx/Asn1/Type/SequenceType.php
+++ b/src/FreeDSx/Asn1/Type/SequenceType.php
@@ -13,12 +13,14 @@ namespace FreeDSx\Asn1\Type;
 /**
  * Represents a Sequence type.
  *
+ * @extends AbstractType<null>
+ *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
 class SequenceType extends AbstractType
 {
     /**
-     * @var int
+     * @var int|string
      */
     protected $tagNumber = self::TAG_TYPE_SEQUENCE;
 
@@ -37,12 +39,16 @@ class SequenceType extends AbstractType
     }
 
     /**
-     * @param string|int $tagNumber
-     * @param int $class
-     * @param array $children
-     * @return SequenceType
+     * @param int|string $tagNumber
+     * @param array<int, AbstractType> $children
+     *
+     * @return static
      */
-    public static function withTag($tagNumber, int $class, array $children = [])
+    public static function withTag(
+        $tagNumber,
+        int $class,
+        array $children = []
+    )
     {
         $type = new static();
         $type->children = $children;

--- a/src/FreeDSx/Asn1/Type/SetType.php
+++ b/src/FreeDSx/Asn1/Type/SetType.php
@@ -13,14 +13,22 @@ namespace FreeDSx\Asn1\Type;
 /**
  * Represents an ASN1 set type.
  *
+ * @extends AbstractType<null>
+ *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
 class SetType extends AbstractType
 {
     use SetTrait;
 
+    /**
+     * @var int|string
+     */
     protected $tagNumber = self::TAG_TYPE_SET;
 
+    /**
+     * @var bool
+     */
     protected $isConstructed = true;
 
     /**
@@ -44,11 +52,15 @@ class SetType extends AbstractType
 
     /**
      * @param int|string $tagNumber
-     * @param int $class
-     * @param array $children
-     * @return SetType
+     * @param array<int, AbstractType> $children
+     *
+     * @return static
      */
-    public static function withTag($tagNumber, int $class, array $children = [])
+    public static function withTag(
+        $tagNumber,
+        int $class,
+        array $children = []
+    )
     {
         $type = new static();
         $type->children = $children;

--- a/tests/bin/asn1-bench-aggregate.php
+++ b/tests/bin/asn1-bench-aggregate.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Aggregate N paired baseline/head encoder bench reports into a single comparison
+ * with median Δ%, per-pair range, and sign-consistency.
+ *
+ * Run with --help to see options.
+ */
+
+use Symfony\Component\Console\Application;
+use Tests\Performance\FreeDSx\Asn1\Aggregate\AggregateCommand;
+
+require __DIR__ . '/../../vendor/autoload.php';
+
+$command = new AggregateCommand();
+$application = new Application('FreeDSx ASN1 bench-aggregate');
+$application->add($command);
+$application->setDefaultCommand(
+    (string) $command->getName(),
+    true,
+);
+$application->run();

--- a/tests/bin/asn1-bench-compare.php
+++ b/tests/bin/asn1-bench-compare.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Diff two single-pair encoder bench reports.
+ *
+ * Run with --help to see options.
+ */
+
+use Symfony\Component\Console\Application;
+use Tests\Performance\FreeDSx\Asn1\Compare\CompareCommand;
+
+require __DIR__ . '/../../vendor/autoload.php';
+
+$command = new CompareCommand();
+$application = new Application('FreeDSx ASN1 bench-compare');
+$application->add($command);
+$application->setDefaultCommand(
+    (string) $command->getName(),
+    true,
+);
+$application->run();

--- a/tests/bin/asn1-bench-floor.php
+++ b/tests/bin/asn1-bench-floor.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Runs the encoder bench and fails if any workload exceeds its budgeted floor
+ * recorded in tests/performance/baseline-floor.json.
+ *
+ * Run with --help to see options.
+ */
+
+use Symfony\Component\Console\Application;
+use Tests\Performance\FreeDSx\Asn1\Floor\FloorCommand;
+
+require __DIR__ . '/../../vendor/autoload.php';
+
+$command = new FloorCommand();
+$application = new Application('FreeDSx ASN1 bench-vs-floor');
+$application->add($command);
+$application->setDefaultCommand(
+    (string) $command->getName(),
+    true,
+);
+$application->run();

--- a/tests/bin/asn1-bench-update-floor.php
+++ b/tests/bin/asn1-bench-update-floor.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Captures current bench numbers + margin and writes a new perf floor JSON.
+ *
+ * Run this on the same hardware/runner the CI floor job uses, then commit the
+ * resulting tests/performance/baseline-floor.json after reviewing the diff.
+ *
+ * Run with --help to see options.
+ */
+
+use Symfony\Component\Console\Application;
+use Tests\Performance\FreeDSx\Asn1\Floor\UpdateFloorCommand;
+
+require __DIR__ . '/../../vendor/autoload.php';
+
+$command = new UpdateFloorCommand();
+$application = new Application('FreeDSx ASN1 bench-update-floor');
+$application->add($command);
+$application->setDefaultCommand(
+    (string) $command->getName(),
+    true,
+);
+$application->run();

--- a/tests/bin/asn1-bench.php
+++ b/tests/bin/asn1-bench.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Bench encoder throughput against representative payloads.
+ *
+ * Run with --help to see the full option list.
+ */
+
+use Symfony\Component\Console\Application;
+use Tests\Performance\FreeDSx\Asn1\Bench\BenchCommand;
+
+require __DIR__ . '/../../vendor/autoload.php';
+
+$command = new BenchCommand();
+$application = new Application('FreeDSx ASN1 bench');
+$application->add($command);
+$application->setDefaultCommand(
+    (string) $command->getName(),
+    true,
+);
+$application->run();

--- a/tests/bin/bench-vs-baseline.sh
+++ b/tests/bin/bench-vs-baseline.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+#
+# Bench HEAD vs working-tree baseline, with N paired runs to weed out noise.
+#
+# Each pair:
+#   1. Stashes the change-under-measurement (src/, tests/unit/, phpstan.tests.neon).
+#   2. Runs `composer bench` against the baseline; saves JSON.
+#   3. Pops the stash.
+#   4. Runs `composer bench` against HEAD; saves JSON.
+#
+# Bench infrastructure (tests/bin/, tests/performance/, composer.json) is NOT
+# stashed — it must remain present for both runs.
+#
+# At the end, all N pairs are aggregated by `asn1-bench-aggregate.php`, which
+# reports median delta, per-pair range, sign-consistency, and a regression
+# verdict. Exits with the aggregator's status.
+#
+# Usage:
+#   composer bench-vs-baseline                       # 5 pairs (default)
+#   composer bench-vs-baseline -- -n 7               # 7 pairs
+#   composer bench-vs-baseline -- -n 7 --threshold=2.0 --consistency=80
+#   composer bench-vs-baseline -- --paths='src/ tests/unit/'  # custom stash scope
+#
+# A `trap` ensures the stash is popped if any single iteration fails, so your
+# working tree is never left in the stashed state.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+PAIRS=5
+STASH_PATHS=(src/ tests/unit/ phpstan.tests.neon)
+EXTRA_AGG_ARGS=()
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -n|--pairs)
+            PAIRS="$2"
+            shift 2
+            ;;
+        --paths=*)
+            # shellcheck disable=SC2206  # word-split into array on purpose
+            STASH_PATHS=(${1#--paths=})
+            shift
+            ;;
+        --threshold=*|--consistency=*)
+            EXTRA_AGG_ARGS+=("$1")
+            shift
+            ;;
+        -h|--help)
+            sed -n '2,28p' "$0" | sed 's/^# \?//'
+            exit 0
+            ;;
+        *)
+            echo "unknown argument: $1" >&2
+            exit 2
+            ;;
+    esac
+done
+
+if [[ ! "$PAIRS" =~ ^[0-9]+$ ]] || (( PAIRS < 1 )); then
+    echo "--pairs must be a positive integer (got: $PAIRS)" >&2
+    exit 2
+fi
+
+if [ -z "$(git status --porcelain -- "${STASH_PATHS[@]}")" ]; then
+    echo "No uncommitted changes within: ${STASH_PATHS[*]}" >&2
+    echo "Override with --paths='dir1 dir2 ...' if needed." >&2
+    exit 1
+fi
+
+RUN_ID="asn1-bench.$$.$(date +%s)"
+RUN_DIR="$(mktemp -d -t "${RUN_ID}.XXXXXX")"
+echo "Run artifacts: ${RUN_DIR}"
+
+STASH_LABEL="bench-vs-baseline-$$"
+STASH_ACTIVE=0
+
+restore_stash() {
+    if (( STASH_ACTIVE == 1 )) && git stash list | grep -q "${STASH_LABEL}"; then
+        echo "--- Restoring stashed changes (cleanup)…" >&2
+        git stash pop --quiet >/dev/null 2>&1 || true
+        STASH_ACTIVE=0
+    fi
+}
+trap restore_stash EXIT INT TERM
+
+BASE_FILES=()
+HEAD_FILES=()
+
+for ((i = 1; i <= PAIRS; i++)); do
+    BASE_OUT="${RUN_DIR}/baseline-${i}.json"
+    HEAD_OUT="${RUN_DIR}/head-${i}.json"
+
+    echo
+    echo "=== Pair ${i}/${PAIRS} — baseline ==="
+    git stash push -u -m "${STASH_LABEL}" --quiet -- "${STASH_PATHS[@]}"
+    STASH_ACTIVE=1
+    composer bench -- --out="${BASE_OUT}"
+
+    echo
+    echo "=== Pair ${i}/${PAIRS} — head ==="
+    git stash pop --quiet
+    STASH_ACTIVE=0
+    composer bench -- --out="${HEAD_OUT}"
+
+    BASE_FILES+=("${BASE_OUT}")
+    HEAD_FILES+=("${HEAD_OUT}")
+done
+
+trap - EXIT INT TERM
+
+echo
+echo "=== Aggregated comparison (${PAIRS} pair$([[ $PAIRS -gt 1 ]] && echo s)) ==="
+
+AGG_ARGS=()
+for f in "${BASE_FILES[@]}"; do
+    AGG_ARGS+=("--baseline=$f")
+done
+for f in "${HEAD_FILES[@]}"; do
+    AGG_ARGS+=("--head=$f")
+done
+composer bench-aggregate -- "${AGG_ARGS[@]}" "${EXTRA_AGG_ARGS[@]}"

--- a/tests/performance/Aggregate/AggregateCommand.php
+++ b/tests/performance/Aggregate/AggregateCommand.php
@@ -1,0 +1,207 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx ASN1 package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Performance\FreeDSx\Asn1\Aggregate;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Tests\Performance\FreeDSx\Asn1\Report\Report;
+use Tests\Performance\FreeDSx\Asn1\Support\Cast;
+use Throwable;
+
+/**
+ * Symfony Console entry point for `composer bench-aggregate`.
+ *
+ * Both --baseline and --head are repeatable; they pair up positionally.
+ *
+ * Example: --baseline=base1.json --baseline=base2.json --head=head1.json --head=head2.json
+ */
+final class AggregateCommand extends Command
+{
+    protected static $defaultName = 'bench-aggregate';
+
+    protected static $defaultDescription = 'Aggregate N paired bench reports with median Δ, range, and sign-consistency.';
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption(
+                'baseline',
+                null,
+                InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
+                'Baseline JSON path (repeat for each pair)',
+            )
+            ->addOption(
+                'head',
+                null,
+                InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
+                'Head JSON path (repeat for each pair)',
+            )
+            ->addOption(
+                'threshold',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Flag |median Δ%| ≥ this value as significant',
+                '3.0',
+            )
+            ->addOption(
+                'consistency',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Required percent of pairs to agree with median direction',
+                '80',
+            );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $baselinePaths = Cast::toStringList($input->getOption('baseline'));
+        $headPaths = Cast::toStringList($input->getOption('head'));
+        $threshold = Cast::toFloat($input->getOption('threshold'), 3.0);
+        $consistencyPc = Cast::toFloat($input->getOption('consistency'), 80.0);
+
+        if ($baselinePaths === [] || $headPaths === [] || count($baselinePaths) !== count($headPaths)) {
+            $output->writeln('<error>--baseline and --head must each be specified the same non-zero number of times.</error>');
+
+            return Command::INVALID;
+        }
+
+        try {
+            $baselineReports = array_map([Report::class, 'fromFile'], $baselinePaths);
+            $headReports = array_map([Report::class, 'fromFile'], $headPaths);
+            $rows = (new Aggregator())->aggregate($baselineReports, $headReports);
+        } catch (Throwable $e) {
+            $output->writeln(sprintf('<error>%s</error>', $e->getMessage()));
+
+            return Command::FAILURE;
+        }
+
+        $pairs = count($baselinePaths);
+        $firstMeta = $baselineReports[0]->meta;
+
+        $output->writeln(sprintf('Pairs:    %d', $pairs));
+        $output->writeln(sprintf(
+            'Baseline: %d files (PHP %s, opcache=%s, jit=%s, assertions=%d)',
+            $pairs,
+            Cast::toString($firstMeta['php'] ?? null, '?'),
+            $this->boolStr($firstMeta['opcache_enabled'] ?? null),
+            Cast::toString($firstMeta['jit'] ?? null, '?'),
+            Cast::toInt($firstMeta['assertions'] ?? null, -1),
+        ));
+        $output->writeln(sprintf('Head:     %d files', $pairs));
+        $output->writeln(sprintf(
+            "Threshold: ±%.1f%%   Consistency required: %.0f%%\n",
+            $threshold,
+            $consistencyPc,
+        ));
+
+        $output->writeln(sprintf(
+            '%-22s %-11s %9s   %-18s   %-12s  %s',
+            'workload',
+            'op',
+            'med Δ%',
+            'range Δ% (per-pair)',
+            'consistency',
+            'significant',
+        ));
+        $output->writeln(str_repeat('-', 100));
+
+        $regressions = [];
+        $improvements = [];
+        foreach ($rows as $row) {
+            $isRegression = $row->isRegression($threshold, $consistencyPc);
+            $isImprovement = $row->isImprovement($threshold, $consistencyPc);
+            if ($isRegression) {
+                $regressions[] = sprintf(
+                    '%s/%s: median +%s%% (%d/%d consistent)',
+                    $row->workload,
+                    $row->op,
+                    number_format($row->medianDeltaPct, 1),
+                    $row->sameDirectionCount,
+                    $row->totalPairs,
+                );
+            } elseif ($isImprovement) {
+                $improvements[] = sprintf(
+                    '%s/%s: median %s%% (%d/%d consistent)',
+                    $row->workload,
+                    $row->op,
+                    number_format($row->medianDeltaPct, 1),
+                    $row->sameDirectionCount,
+                    $row->totalPairs,
+                );
+            }
+
+            $marker = '   ';
+            if ($isRegression) {
+                $marker = '!! ';
+            } elseif ($isImprovement) {
+                $marker = ' + ';
+            }
+
+            $output->writeln(sprintf(
+                '%-22s %-11s %+8.1f%%  [%+5.1f, %+5.1f]   %2d/%-2d (%3.0f%%)   %s',
+                $row->workload,
+                $row->op,
+                $row->medianDeltaPct,
+                $row->minDeltaPct,
+                $row->maxDeltaPct,
+                $row->sameDirectionCount,
+                $row->totalPairs,
+                $row->consistencyPct(),
+                $marker . ($isRegression ? 'REGRESSION' : ($isImprovement ? 'improvement' : '')),
+            ));
+        }
+        $output->writeln('');
+
+        if ($improvements !== []) {
+            $output->writeln('Improvements:');
+            foreach ($improvements as $line) {
+                $output->writeln('  ' . $line);
+            }
+            $output->writeln('');
+        }
+
+        if ($regressions === []) {
+            $output->writeln(sprintf(
+                'OK — no significant regressions (threshold ±%.1f%%, consistency ≥ %.0f%%)',
+                $threshold,
+                $consistencyPc,
+            ));
+
+            return Command::SUCCESS;
+        }
+        $output->writeln(sprintf(
+            'REGRESSION — %d workload/op pair(s) crossed the threshold:',
+            count($regressions),
+        ));
+        foreach ($regressions as $line) {
+            $output->writeln('  ' . $line);
+        }
+
+        return Command::FAILURE;
+    }
+
+    private function boolStr(mixed $v): string
+    {
+        if ($v === true) {
+            return 'on';
+        }
+        if ($v === false) {
+            return 'off';
+        }
+
+        return '?';
+    }
+}

--- a/tests/performance/Aggregate/AggregatedRow.php
+++ b/tests/performance/Aggregate/AggregatedRow.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx ASN1 package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Performance\FreeDSx\Asn1\Aggregate;
+
+/**
+ * One workload/op's aggregated stats across N paired runs.
+ */
+final readonly class AggregatedRow
+{
+    public function __construct(
+        public string $workload,
+        public string $op,
+        public float  $medianDeltaPct,
+        public float  $minDeltaPct,
+        public float  $maxDeltaPct,
+        public int    $sameDirectionCount,
+        public int    $totalPairs,
+    ) {
+    }
+
+    public function consistencyPct(): float
+    {
+        if ($this->totalPairs === 0) {
+            return 0.0;
+        }
+
+        return $this->sameDirectionCount / $this->totalPairs * 100.0;
+    }
+
+    public function isSignificant(
+        float $thresholdPct,
+        float $consistencyPct
+    ): bool {
+        return abs($this->medianDeltaPct) >= $thresholdPct
+            && $this->consistencyPct() >= $consistencyPct;
+    }
+
+    public function isRegression(
+        float $thresholdPct,
+        float $consistencyPct
+    ): bool {
+        return $this->isSignificant($thresholdPct, $consistencyPct) && $this->medianDeltaPct > 0;
+    }
+
+    public function isImprovement(
+        float $thresholdPct,
+        float $consistencyPct
+    ): bool {
+        return $this->isSignificant($thresholdPct, $consistencyPct) && $this->medianDeltaPct < 0;
+    }
+}

--- a/tests/performance/Aggregate/Aggregator.php
+++ b/tests/performance/Aggregate/Aggregator.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx ASN1 package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Performance\FreeDSx\Asn1\Aggregate;
+
+use InvalidArgumentException;
+use Tests\Performance\FreeDSx\Asn1\Report\Report;
+use Tests\Performance\FreeDSx\Asn1\Report\WorkloadResult;
+
+/**
+ * Aggregates N paired baseline/head bench reports into per-workload/op
+ * median delta + range + sign-consistency metrics.
+ */
+final class Aggregator
+{
+    /**
+     * @param list<Report> $baselineReports
+     * @param list<Report> $headReports
+     *
+     * @return list<AggregatedRow>
+     */
+    public function aggregate(
+        array $baselineReports,
+        array $headReports,
+    ): array {
+        if ($baselineReports === [] || $headReports === [] || count($baselineReports) !== count($headReports)) {
+            throw new InvalidArgumentException(
+                'Aggregator needs the same non-zero number of baseline and head reports.',
+            );
+        }
+        $pairs = count($baselineReports);
+        $names = $this->collectWorkloadNames($baselineReports, $headReports);
+
+        $rows = [];
+        foreach ($names as $name) {
+            foreach (WorkloadResult::operations() as $op) {
+                $deltas = $this->perPairDeltas($baselineReports, $headReports, $name, $op, $pairs);
+                if ($deltas === []) {
+                    continue;
+                }
+                sort($deltas);
+                $count = count($deltas);
+                $median = $deltas[intdiv($count, 2)];
+                $sign = $median >= 0 ? 1 : -1;
+                $sameDir = count(array_filter(
+                    $deltas,
+                    static fn (float $d): bool => $sign === 1 ? $d >= 0 : $d <= 0,
+                ));
+
+                $rows[] = new AggregatedRow(
+                    workload: $name,
+                    op: $op,
+                    medianDeltaPct: $median,
+                    minDeltaPct: $deltas[0],
+                    maxDeltaPct: $deltas[$count - 1],
+                    sameDirectionCount: $sameDir,
+                    totalPairs: $count,
+                );
+            }
+        }
+
+        return $rows;
+    }
+
+    /**
+     * @param list<Report> $baselineReports
+     * @param list<Report> $headReports
+     *
+     * @return list<float>
+     */
+    private function perPairDeltas(
+        array $baselineReports,
+        array $headReports,
+        string $name,
+        string $op,
+        int $pairs,
+    ): array {
+        $deltas = [];
+        for ($i = 0; $i < $pairs; $i++) {
+            $base = $baselineReports[$i]->workloads[$name] ?? null;
+            $head = $headReports[$i]->workloads[$name] ?? null;
+            if ($base === null || $head === null) {
+                continue;
+            }
+            $b = $base->op($op)->nsPerPayload;
+            $h = $head->op($op)->nsPerPayload;
+            if ($b <= 0.0) {
+                continue;
+            }
+            $deltas[] = ($h - $b) / $b * 100.0;
+        }
+
+        return $deltas;
+    }
+
+    /**
+     * @param list<Report> $base
+     * @param list<Report> $head
+     *
+     * @return list<string>
+     */
+    private function collectWorkloadNames(array $base, array $head): array
+    {
+        $names = [];
+        foreach ([...$base, ...$head] as $report) {
+            foreach (array_keys($report->workloads) as $name) {
+                $names[$name] = true;
+            }
+        }
+
+        return array_keys($names);
+    }
+}

--- a/tests/performance/Bench/BenchCommand.php
+++ b/tests/performance/Bench/BenchCommand.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx ASN1 package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Performance\FreeDSx\Asn1\Bench;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Tests\Performance\FreeDSx\Asn1\Support\Cast;
+use Throwable;
+
+/**
+ * Symfony Console entry point for `composer bench`.
+ */
+final class BenchCommand extends Command
+{
+    protected static $defaultName = 'bench';
+
+    protected static $defaultDescription = 'Run encoder benchmarks against representative payloads.';
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption('encoder', null, InputOption::VALUE_REQUIRED, 'Encoder under test: ber | der', 'ber')
+            ->addOption('workload', null, InputOption::VALUE_REQUIRED, 'Run a single workload only (default: all)')
+            ->addOption('warmup', null, InputOption::VALUE_REQUIRED, 'Warmup iterations discarded', '2')
+            ->addOption('samples', null, InputOption::VALUE_REQUIRED, 'Timed samples taken', '7')
+            ->addOption('revs', null, InputOption::VALUE_REQUIRED, 'Inner repetitions per sample', '3')
+            ->addOption('json', null, InputOption::VALUE_NONE, 'Emit JSON to stdout (machine-readable)')
+            ->addOption('out', null, InputOption::VALUE_REQUIRED, 'Write JSON report to PATH');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $opts = new BenchOptions(
+            encoder: Cast::toString($input->getOption('encoder'), 'ber'),
+            workload: Cast::toStringOrNull($input->getOption('workload')),
+            warmup: Cast::toInt($input->getOption('warmup'), 2),
+            samples: Cast::toInt($input->getOption('samples'), 7),
+            revs: Cast::toInt($input->getOption('revs'), 3),
+        );
+
+        $emitJson = Cast::toBool($input->getOption('json'));
+        $outPath = Cast::toStringOrNull($input->getOption('out'));
+
+        $progress = $emitJson
+            ? null
+            : static function (string $line) use ($output): void {
+                $output->writeln($line);
+            };
+
+        try {
+            $report = (new Benchmarker())->run($opts, $progress);
+        } catch (Throwable $e) {
+            $output->writeln(sprintf('<error>%s</error>', $e->getMessage()));
+
+            return Command::FAILURE;
+        }
+
+        if ($outPath !== null) {
+            $report->writeTo($outPath);
+            if (!$emitJson) {
+                $output->writeln(sprintf('wrote %s', $outPath));
+            }
+        }
+        if ($emitJson) {
+            $output->write($report->toJson());
+        }
+
+        return Command::SUCCESS;
+    }
+}

--- a/tests/performance/Bench/BenchOptions.php
+++ b/tests/performance/Bench/BenchOptions.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx ASN1 package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Performance\FreeDSx\Asn1\Bench;
+
+/**
+ * Immutable knobs controlling a bench run.
+ */
+final readonly class BenchOptions
+{
+    public function __construct(
+        public string  $encoder = 'ber',
+        public ?string $workload = null,
+        public int     $warmup = 2,
+        public int     $samples = 7,
+        public int     $revs = 3,
+    ) {
+    }
+}

--- a/tests/performance/Bench/Benchmarker.php
+++ b/tests/performance/Bench/Benchmarker.php
@@ -1,0 +1,211 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx ASN1 package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Performance\FreeDSx\Asn1\Bench;
+
+use FreeDSx\Asn1\Encoder\BerEncoder;
+use FreeDSx\Asn1\Encoder\DerEncoder;
+use FreeDSx\Asn1\Encoder\EncoderInterface;
+use FreeDSx\Asn1\Type\AbstractType;
+use InvalidArgumentException;
+use Tests\Performance\FreeDSx\Asn1\Report\OpResult;
+use Tests\Performance\FreeDSx\Asn1\Report\Report;
+use Tests\Performance\FreeDSx\Asn1\Report\WorkloadResult;
+use Tests\Performance\FreeDSx\Asn1\Workload;
+
+/**
+ * Runs encode / decode / round-trip timings against a Workload corpus and
+ * produces a Report. Stateless apart from the EncoderInterface it constructs.
+ */
+final class Benchmarker
+{
+    /**
+     * LDAP-style application-class tag map (mirrors freedsx/ldap LdapEncoder).
+     * Workloads exercising application-tagged payloads use this so decode
+     * unfolds the inner structure rather than leaving an IncompleteType.
+     *
+     * @var array<int, array<int, int>>
+     */
+    private const LDAP_TAG_MAP = [
+        AbstractType::TAG_CLASS_APPLICATION => [
+            0 => AbstractType::TAG_TYPE_SEQUENCE,
+            1 => AbstractType::TAG_TYPE_SEQUENCE,
+            2 => AbstractType::TAG_TYPE_NULL,
+            3 => AbstractType::TAG_TYPE_SEQUENCE,
+            4 => AbstractType::TAG_TYPE_SEQUENCE,
+            5 => AbstractType::TAG_TYPE_SEQUENCE,
+            6 => AbstractType::TAG_TYPE_SEQUENCE,
+            7 => AbstractType::TAG_TYPE_SEQUENCE,
+            8 => AbstractType::TAG_TYPE_SEQUENCE,
+            9 => AbstractType::TAG_TYPE_SEQUENCE,
+            10 => AbstractType::TAG_TYPE_OCTET_STRING,
+            11 => AbstractType::TAG_TYPE_SEQUENCE,
+            12 => AbstractType::TAG_TYPE_SEQUENCE,
+            13 => AbstractType::TAG_TYPE_SEQUENCE,
+            14 => AbstractType::TAG_TYPE_SEQUENCE,
+            15 => AbstractType::TAG_TYPE_SEQUENCE,
+            16 => AbstractType::TAG_TYPE_INTEGER,
+            19 => AbstractType::TAG_TYPE_SEQUENCE,
+            23 => AbstractType::TAG_TYPE_SEQUENCE,
+            24 => AbstractType::TAG_TYPE_SEQUENCE,
+            25 => AbstractType::TAG_TYPE_SEQUENCE,
+        ],
+    ];
+
+    /**
+     * Workloads that need the LDAP tag map at decode time.
+     *
+     * @var list<string>
+     */
+    private const WORKLOADS_USING_LDAP_TAG_MAP = ['mixed_message'];
+
+    /**
+     * @param callable(string): void|null $progress  Optional progress sink (workload-line callback).
+     */
+    public function run(BenchOptions $opts, ?callable $progress = null): Report
+    {
+        $encoder = $this->buildEncoder($opts->encoder);
+        $workloads = $this->resolveWorkloads($opts->workload);
+
+        $meta = [
+            'php' => PHP_VERSION,
+            'opcache_enabled' => function_exists('opcache_get_status')
+                && (opcache_get_status(false)['opcache_enabled'] ?? false),
+            'jit' => (string) ini_get('opcache.jit'),
+            'assertions' => (int) ini_get('zend.assertions'),
+            'encoder' => $opts->encoder,
+            'warmup' => $opts->warmup,
+            'samples' => $opts->samples,
+            'revs' => $opts->revs,
+            'started' => date('c'),
+        ];
+
+        $results = [];
+        foreach ($workloads as $name => $payloads) {
+            $tagMap = in_array($name, self::WORKLOADS_USING_LDAP_TAG_MAP, true)
+                ? self::LDAP_TAG_MAP
+                : [];
+            $encodedCorpus = array_map(
+                static fn (AbstractType $t): string => $encoder->encode($t),
+                $payloads,
+            );
+            $payloadCount = count($payloads);
+            $byteCount = array_sum(array_map('strlen', $encodedCorpus));
+
+            $encodeNs = $this->measure(
+                static function () use ($encoder, $payloads): void {
+                    foreach ($payloads as $t) {
+                        $encoder->encode($t);
+                    }
+                },
+                $opts,
+            );
+
+            $decodeNs = $this->measure(
+                static function () use ($encoder, $encodedCorpus, $tagMap): void {
+                    foreach ($encodedCorpus as $bin) {
+                        $encoder->decode($bin, $tagMap);
+                    }
+                },
+                $opts,
+            );
+
+            $roundTripNs = $this->measure(
+                static function () use ($encoder, $payloads, $tagMap): void {
+                    foreach ($payloads as $t) {
+                        $encoder->decode($encoder->encode($t), $tagMap);
+                    }
+                },
+                $opts,
+            );
+
+            $results[$name] = new WorkloadResult(
+                payloads: $payloadCount,
+                encodedBytes: $byteCount,
+                encode: OpResult::fromSamples($encodeNs, $payloadCount),
+                decode: OpResult::fromSamples($decodeNs, $payloadCount),
+                roundTrip: OpResult::fromSamples($roundTripNs, $payloadCount),
+            );
+
+            if ($progress !== null) {
+                $progress($this->formatProgressLine($name, $results[$name]));
+            }
+        }
+
+        return new Report(meta: $meta, workloads: $results);
+    }
+
+    /**
+     * @return array<string, list<AbstractType<mixed>>>
+     */
+    private function resolveWorkloads(?string $only): array
+    {
+        $all = Workload::all();
+        if ($only === null) {
+            return $all;
+        }
+        if (!isset($all[$only])) {
+            throw new InvalidArgumentException("Unknown workload: $only");
+        }
+
+        return [$only => $all[$only]];
+    }
+
+    private function buildEncoder(string $name): EncoderInterface
+    {
+        return match ($name) {
+            'ber' => new BerEncoder(),
+            'der' => new DerEncoder(),
+            default => throw new InvalidArgumentException("--encoder must be ber or der (got: $name)"),
+        };
+    }
+
+    /**
+     * @param callable(): void $fn
+     *
+     * @return list<int> Per-sample wall-clock duration in nanoseconds.
+     */
+    private function measure(callable $fn, BenchOptions $opts): array
+    {
+        for ($i = 0; $i < $opts->warmup; $i++) {
+            $fn();
+        }
+        $samples = [];
+        for ($s = 0; $s < $opts->samples; $s++) {
+            $start = hrtime(true);
+            for ($r = 0; $r < $opts->revs; $r++) {
+                $fn();
+            }
+            $samples[] = (int) ((hrtime(true) - $start) / max(1, $opts->revs));
+        }
+
+        return $samples;
+    }
+
+    private function formatProgressLine(string $name, WorkloadResult $w): string
+    {
+        return sprintf(
+            "%-22s payloads=%-5d  encode=%s  decode=%s  rt=%s",
+            $name,
+            $w->payloads,
+            $this->fmtPerOp($w->encode->nsPerPayload, $w->encode->opsPerSec),
+            $this->fmtPerOp($w->decode->nsPerPayload, $w->decode->opsPerSec),
+            $this->fmtPerOp($w->roundTrip->nsPerPayload, $w->roundTrip->opsPerSec),
+        );
+    }
+
+    private function fmtPerOp(float $nsPerPayload, float $opsPerSec): string
+    {
+        return sprintf('%7.0f ns/payload (%6.0f loops/s)', $nsPerPayload, $opsPerSec);
+    }
+}

--- a/tests/performance/Compare/Comparator.php
+++ b/tests/performance/Compare/Comparator.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx ASN1 package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Performance\FreeDSx\Asn1\Compare;
+
+use Tests\Performance\FreeDSx\Asn1\Report\Report;
+use Tests\Performance\FreeDSx\Asn1\Report\WorkloadResult;
+
+/**
+ * Computes per-workload/op deltas between two single-pair reports.
+ */
+final class Comparator
+{
+    /**
+     * @return list<ComparisonRow>
+     */
+    public function compare(
+        Report $baseline,
+        Report $head
+    ): array {
+        $names = array_unique(array_merge(
+            array_keys($baseline->workloads),
+            array_keys($head->workloads),
+        ));
+        $rows = [];
+        foreach ($names as $name) {
+            $rows[] = new ComparisonRow(
+                workload: $name,
+                baseline: $baseline->workloads[$name] ?? null,
+                head: $head->workloads[$name] ?? null,
+            );
+        }
+
+        return $rows;
+    }
+
+    /**
+     * @param list<ComparisonRow> $rows
+     */
+    public function worstAbsoluteDelta(array $rows): float
+    {
+        $worst = 0.0;
+        foreach ($rows as $row) {
+            foreach (WorkloadResult::operations() as $op) {
+                $worst = max($worst, abs($row->deltaPctFor($op)));
+            }
+        }
+
+        return $worst;
+    }
+
+    /**
+     * @param list<ComparisonRow> $rows
+     *
+     * @return list<string>
+     */
+    public function regressions(
+        array $rows,
+        float $thresholdPct
+    ): array {
+        $out = [];
+
+        foreach ($rows as $row) {
+            foreach (WorkloadResult::operations() as $op) {
+                $delta = $row->deltaPctFor($op);
+                if ($delta > $thresholdPct) {
+                    $out[] = sprintf('%s/%s: +%s%%', $row->workload, $op, number_format($delta, 1));
+                }
+            }
+        }
+
+        return $out;
+    }
+}

--- a/tests/performance/Compare/CompareCommand.php
+++ b/tests/performance/Compare/CompareCommand.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx ASN1 package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Performance\FreeDSx\Asn1\Compare;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Tests\Performance\FreeDSx\Asn1\Report\Report;
+use Tests\Performance\FreeDSx\Asn1\Support\Cast;
+use Throwable;
+
+/**
+ * Symfony Console entry point for `composer bench-compare`.
+ */
+final class CompareCommand extends Command
+{
+    protected static $defaultName = 'bench-compare';
+
+    protected static $defaultDescription = 'Diff two single-pair bench reports.';
+
+    protected function configure(): void
+    {
+        $this
+            ->addArgument('baseline', InputArgument::REQUIRED, 'Path to baseline report JSON')
+            ->addArgument('head', InputArgument::REQUIRED, 'Path to head report JSON')
+            ->addOption('threshold', null, InputOption::VALUE_REQUIRED, 'Flag changes greater than ±PCT', '3.0');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $threshold = Cast::toFloat($input->getOption('threshold'), 3.0);
+        $baselinePath = Cast::toString($input->getArgument('baseline'));
+        $headPath = Cast::toString($input->getArgument('head'));
+
+        try {
+            $baseline = Report::fromFile($baselinePath);
+            $head = Report::fromFile($headPath);
+        } catch (Throwable $e) {
+            $output->writeln(sprintf('<error>%s</error>', $e->getMessage()));
+
+            return Command::FAILURE;
+        }
+
+        $output->writeln(sprintf(
+            'Baseline: %s  (PHP %s, opcache=%s, jit=%s, assertions=%d)',
+            $baselinePath,
+            Cast::toString($baseline->meta['php'] ?? null, '?'),
+            $this->boolStr($baseline->meta['opcache_enabled'] ?? null),
+            Cast::toString($baseline->meta['jit'] ?? null, '?'),
+            Cast::toInt($baseline->meta['assertions'] ?? null, -1),
+        ));
+        $output->writeln(sprintf(
+            "Head:     %s  (PHP %s, opcache=%s, jit=%s, assertions=%d)\n",
+            $headPath,
+            Cast::toString($head->meta['php'] ?? null, '?'),
+            $this->boolStr($head->meta['opcache_enabled'] ?? null),
+            Cast::toString($head->meta['jit'] ?? null, '?'),
+            Cast::toInt($head->meta['assertions'] ?? null, -1),
+        ));
+
+        $comparator = new Comparator();
+        $rows = $comparator->compare($baseline, $head);
+
+        $output->writeln(sprintf(
+            "%-22s  %-25s  %-25s  %-25s",
+            'workload',
+            'encode (Δ%)',
+            'decode (Δ%)',
+            'round-trip (Δ%)',
+        ));
+        $output->writeln(str_repeat('-', 100));
+
+        foreach ($rows as $row) {
+            if (!$row->isComplete()) {
+                $output->writeln(sprintf('%-22s  (missing on one side)', $row->workload));
+                continue;
+            }
+            $output->writeln(sprintf(
+                '%-22s  %-25s  %-25s  %-25s',
+                $row->workload,
+                $this->fmtCell($row, 'encode', $threshold),
+                $this->fmtCell($row, 'decode', $threshold),
+                $this->fmtCell($row, 'round_trip', $threshold),
+            ));
+        }
+        $output->writeln('');
+
+        $regressions = $comparator->regressions($rows, $threshold);
+        $worst = $comparator->worstAbsoluteDelta($rows);
+
+        if ($regressions === []) {
+            $output->writeln(sprintf(
+                'OK — no regression beyond ±%.1f%% (worst |Δ| = %.1f%%)',
+                $threshold,
+                $worst,
+            ));
+
+            return Command::SUCCESS;
+        }
+        $output->writeln(sprintf(
+            'REGRESSION — %d workload/op pairs exceeded +%.1f%%:',
+            count($regressions),
+            $threshold,
+        ));
+        foreach ($regressions as $line) {
+            $output->writeln('  ' . $line);
+        }
+
+        return Command::FAILURE;
+    }
+
+    private function fmtCell(ComparisonRow $row, string $op, float $threshold): string
+    {
+        $delta = $row->deltaPctFor($op);
+        $marker = ' ';
+        if ($delta > $threshold) {
+            $marker = '!';
+        } elseif ($delta < -$threshold) {
+            $marker = '+';
+        }
+
+        return sprintf(
+            '%6.0f→%6.0f ns %+5.1f%% %s',
+            $row->baselineNsFor($op),
+            $row->headNsFor($op),
+            $delta,
+            $marker,
+        );
+    }
+
+    private function boolStr(mixed $v): string
+    {
+        if ($v === true) {
+            return 'on';
+        }
+        if ($v === false) {
+            return 'off';
+        }
+
+        return '?';
+    }
+}

--- a/tests/performance/Compare/ComparisonRow.php
+++ b/tests/performance/Compare/ComparisonRow.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx ASN1 package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Performance\FreeDSx\Asn1\Compare;
+
+use Tests\Performance\FreeDSx\Asn1\Report\WorkloadResult;
+
+/**
+ * One workload's baseline-vs-head numbers, with helpers for per-op deltas.
+ */
+final readonly class ComparisonRow
+{
+    public function __construct(
+        public string          $workload,
+        public ?WorkloadResult $baseline,
+        public ?WorkloadResult $head,
+    ) {
+    }
+
+    public function isComplete(): bool
+    {
+        return $this->baseline !== null && $this->head !== null;
+    }
+
+    public function deltaPctFor(string $op): float
+    {
+        if (!$this->isComplete()) {
+            return 0.0;
+        }
+        \assert($this->baseline !== null && $this->head !== null);
+        $base = $this->baseline->op($op)->nsPerPayload;
+        $head = $this->head->op($op)->nsPerPayload;
+        if ($base <= 0.0) {
+            return 0.0;
+        }
+
+        return (($head - $base) / $base) * 100.0;
+    }
+
+    public function baselineNsFor(string $op): float
+    {
+        return $this->baseline?->op($op)->nsPerPayload ?? 0.0;
+    }
+
+    public function headNsFor(string $op): float
+    {
+        return $this->head?->op($op)->nsPerPayload ?? 0.0;
+    }
+}

--- a/tests/performance/Floor/FloorCommand.php
+++ b/tests/performance/Floor/FloorCommand.php
@@ -1,0 +1,173 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx ASN1 package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Performance\FreeDSx\Asn1\Floor;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Tests\Performance\FreeDSx\Asn1\Bench\Benchmarker;
+use Tests\Performance\FreeDSx\Asn1\Bench\BenchOptions;
+use Tests\Performance\FreeDSx\Asn1\Report\Report;
+use Tests\Performance\FreeDSx\Asn1\Support\Cast;
+use Throwable;
+
+/**
+ * `composer bench-vs-floor` — runs the bench and fails if any workload/op
+ * exceeds the per-operation ceiling recorded in tests/performance/baseline-floor.json.
+ */
+final class FloorCommand extends Command
+{
+    protected static $defaultName = 'bench-vs-floor';
+
+    protected static $defaultDescription = 'Run the bench and check that no workload exceeds its perf budget.';
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption(
+                'floor',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Path to the floor JSON',
+                __DIR__ . '/../baseline-floor.json',
+            )
+            ->addOption(
+                'samples',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Bench samples per workload',
+                '7',
+            )
+            ->addOption(
+                'revs',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Inner repetitions per sample',
+                '3',
+            );
+    }
+
+    protected function execute(
+        InputInterface $input,
+        OutputInterface $output
+    ): int {
+        $floorPath = Cast::toString($input->getOption('floor'));
+        $samples   = Cast::toInt($input->getOption('samples'), 7);
+        $revs      = Cast::toInt($input->getOption('revs'), 3);
+
+        try {
+            $floor = FloorReport::fromFile($floorPath);
+        } catch (Throwable $e) {
+            $output->writeln(sprintf('<error>%s</error>', $e->getMessage()));
+
+            return Command::FAILURE;
+        }
+
+        $output->writeln(sprintf(
+            'Floor: %s   margin=%d%%   captured_on=%s   runner=%s',
+            $floorPath,
+            $floor->marginPct,
+            $floor->capturedOn,
+            $floor->runner,
+        ));
+        $output->writeln('');
+
+        try {
+            $report = (new Benchmarker())->run(new BenchOptions(
+                samples: $samples,
+                revs: $revs,
+            ));
+        } catch (Throwable $e) {
+            $output->writeln(sprintf('<error>Bench failed: %s</error>', $e->getMessage()));
+
+            return Command::FAILURE;
+        }
+
+        return $this->renderAndJudge(
+            $floor,
+            $report,
+            $output,
+        );
+    }
+
+    private function renderAndJudge(
+        FloorReport $floor,
+        Report $report,
+        OutputInterface $output
+    ): int {
+        $output->writeln(sprintf(
+            '%-22s %-11s %12s %12s   %s',
+            'workload',
+            'op',
+            'measured',
+            'floor',
+            'verdict',
+        ));
+        $output->writeln(str_repeat('-', 80));
+
+        $breaches = [];
+        foreach ($floor->budget as $name => $ops) {
+            $workload = $report->workloads[$name] ?? null;
+            if ($workload === null) {
+                $output->writeln(sprintf('%-22s (workload not run)', $name));
+                continue;
+            }
+            foreach ($ops as $op => $ceilingNs) {
+                $measured = $workload->op($op)->nsPerPayload;
+                $exceeds  = $measured > $ceilingNs;
+                $marker   = $exceeds ? '!! OVER' : '   ok';
+
+                if ($exceeds) {
+                    $breaches[] = sprintf(
+                        '%s/%s: measured %.0f ns/payload > floor %d ns/payload (%+0.1f%%)',
+                        $name,
+                        $op,
+                        $measured,
+                        $ceilingNs,
+                        ($measured - $ceilingNs) / $ceilingNs * 100.0,
+                    );
+                }
+
+                $output->writeln(sprintf(
+                    '%-22s %-11s %10.0f ns %10d ns   %s',
+                    $name,
+                    $op,
+                    $measured,
+                    $ceilingNs,
+                    $marker,
+                ));
+            }
+        }
+        $output->writeln('');
+
+        if ($breaches === []) {
+            $output->writeln(sprintf(
+                '<info>OK — all %d budgeted operations under their floor.</info>',
+                $floor->totalBudgetedOps(),
+            ));
+
+            return Command::SUCCESS;
+        }
+        $output->writeln(sprintf(
+            '<error>FLOOR BREACH — %d operation(s) exceeded their budget:</error>',
+            count($breaches),
+        ));
+        foreach ($breaches as $line) {
+            $output->writeln('  ' . $line);
+        }
+
+        return Command::FAILURE;
+    }
+}

--- a/tests/performance/Floor/FloorReport.php
+++ b/tests/performance/Floor/FloorReport.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx ASN1 package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Performance\FreeDSx\Asn1\Floor;
+
+use InvalidArgumentException;
+use RuntimeException;
+use Tests\Performance\FreeDSx\Asn1\Support\Cast;
+
+/**
+ * Parsed view of baseline-floor.json.
+ */
+final readonly class FloorReport
+{
+    /**
+     * @param array<string, array<string, int>> $budget Workload => (op => max ns/payload).
+     */
+    public function __construct(
+        public string $capturedOn,
+        public string $runner,
+        public int $marginPct,
+        public array $budget,
+    ) {
+    }
+
+    public static function fromFile(string $path): self
+    {
+        if (!is_file($path)) {
+            throw new InvalidArgumentException("Floor file not found: $path");
+        }
+        $raw = file_get_contents($path);
+        if ($raw === false) {
+            throw new RuntimeException("Failed to read floor file: $path");
+        }
+        $data = json_decode($raw, true);
+        if (!is_array($data)) {
+            throw new InvalidArgumentException("Malformed floor JSON: $path");
+        }
+
+        $rawMeta   = is_array($data['meta'] ?? null) ? $data['meta'] : [];
+        $rawBudget = is_array($data['floor_ns_per_payload'] ?? null) ? $data['floor_ns_per_payload'] : [];
+
+        /** @var array<string, array<string, int>> $budget */
+        $budget = [];
+        foreach ($rawBudget as $name => $ops) {
+            if (!is_string($name) || !is_array($ops)) {
+                continue;
+            }
+            $entry = [];
+            foreach ($ops as $op => $ceiling) {
+                if (is_string($op) && (is_int($ceiling) || is_float($ceiling))) {
+                    $entry[$op] = (int) $ceiling;
+                }
+            }
+            $budget[$name] = $entry;
+        }
+
+        return new self(
+            capturedOn: Cast::toString($rawMeta['captured_on'] ?? null, '?'),
+            runner: Cast::toString($rawMeta['runner'] ?? null, '?'),
+            marginPct: Cast::toInt($rawMeta['margin_pct'] ?? null, 0),
+            budget: $budget,
+        );
+    }
+
+    public function totalBudgetedOps(): int
+    {
+        $n = 0;
+        foreach ($this->budget as $ops) {
+            $n += count($ops);
+        }
+
+        return $n;
+    }
+}

--- a/tests/performance/Floor/UpdateFloorCommand.php
+++ b/tests/performance/Floor/UpdateFloorCommand.php
@@ -1,0 +1,172 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx ASN1 package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Performance\FreeDSx\Asn1\Floor;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Tests\Performance\FreeDSx\Asn1\Bench\Benchmarker;
+use Tests\Performance\FreeDSx\Asn1\Bench\BenchOptions;
+use Tests\Performance\FreeDSx\Asn1\Support\Cast;
+use Throwable;
+
+/**
+ * `composer bench-update-floor` — runs the bench, applies a margin to each
+ * measurement, and writes a new tests/performance/baseline-floor.json.
+ *
+ * Run this on the same kind of machine the CI floor job uses (ubuntu-latest)
+ * after intentional perf changes; review the diff and commit.
+ */
+final class UpdateFloorCommand extends Command
+{
+    /**
+     * Workloads to omit from the floor (synthetic / too-noisy to budget).
+     *
+     * @var list<string>
+     */
+    private const EXCLUDED_WORKLOADS = ['primitives_baseline'];
+
+    protected static $defaultName = 'bench-update-floor';
+
+    protected static $defaultDescription = 'Capture current bench numbers + margin as the new perf floor.';
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption(
+                'out',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Output JSON path',
+                __DIR__ . '/../baseline-floor.json',
+            )
+            ->addOption(
+                'margin',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Headroom percent above measured (default 20)',
+                '20',
+            )
+            ->addOption(
+                'samples',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Bench samples per workload (more = stabler)',
+                '15',
+            )
+            ->addOption(
+                'revs',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Inner repetitions per sample',
+                '5',
+            )
+            ->addOption(
+                'runner',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Runner label to record in meta',
+                getenv('RUNNER_OS') !== false ? strtolower((string) getenv('RUNNER_OS')) : 'local',
+            );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $outPath  = Cast::toString($input->getOption('out'));
+        $margin   = Cast::toInt($input->getOption('margin'), 20);
+        $samples  = Cast::toInt($input->getOption('samples'), 15);
+        $revs     = Cast::toInt($input->getOption('revs'), 5);
+        $runner   = Cast::toString($input->getOption('runner'), 'local');
+
+        $output->writeln(sprintf(
+            'Capturing floor: samples=%d revs=%d margin=%d%% runner=%s',
+            $samples,
+            $revs,
+            $margin,
+            $runner,
+        ));
+        $output->writeln('');
+
+        try {
+            $report = (new Benchmarker())->run(new BenchOptions(
+                samples: $samples,
+                revs: $revs,
+            ));
+        } catch (Throwable $e) {
+            $output->writeln(sprintf('<error>Bench failed: %s</error>', $e->getMessage()));
+
+            return Command::FAILURE;
+        }
+
+        $multiplier = 1.0 + ($margin / 100.0);
+
+        /** @var array<string, array<string, int>> $budget */
+        $budget = [];
+        foreach ($report->workloads as $name => $workload) {
+            if (in_array($name, self::EXCLUDED_WORKLOADS, true)) {
+                continue;
+            }
+            $budget[$name] = [
+                'encode'     => (int) ceil($workload->encode->nsPerPayload * $multiplier),
+                'decode'     => (int) ceil($workload->decode->nsPerPayload * $multiplier),
+                'round_trip' => (int) ceil($workload->roundTrip->nsPerPayload * $multiplier),
+            ];
+        }
+
+        $payload = [
+            'meta' => [
+                'captured_on' => date('Y-m-d'),
+                'runner'      => $runner,
+                'php'         => PHP_VERSION,
+                'margin_pct'  => $margin,
+                'note'        => sprintf(
+                    'Captured %s with samples=%d revs=%d. Each value = measured ns/payload * %.2f.',
+                    date('c'),
+                    $samples,
+                    $revs,
+                    $multiplier,
+                ),
+            ],
+            'floor_ns_per_payload' => $budget,
+        ];
+
+        $json = json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+        if ($json === false) {
+            $output->writeln('<error>Failed to encode floor JSON.</error>');
+
+            return Command::FAILURE;
+        }
+        if (file_put_contents($outPath, $json . "\n") === false) {
+            $output->writeln(sprintf('<error>Failed to write floor file: %s</error>', $outPath));
+
+            return Command::FAILURE;
+        }
+
+        $output->writeln('Captured numbers (with margin applied):');
+        foreach ($budget as $name => $ops) {
+            $output->writeln(sprintf(
+                '  %-22s encode=%d  decode=%d  round_trip=%d',
+                $name,
+                $ops['encode'],
+                $ops['decode'],
+                $ops['round_trip'],
+            ));
+        }
+        $output->writeln('');
+        $output->writeln(sprintf('<info>Wrote %s — review the diff and commit.</info>', $outPath));
+
+        return Command::SUCCESS;
+    }
+}

--- a/tests/performance/Report/OpResult.php
+++ b/tests/performance/Report/OpResult.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx ASN1 package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Performance\FreeDSx\Asn1\Report;
+
+use Tests\Performance\FreeDSx\Asn1\Support\Cast;
+
+/**
+ * Per-operation timing summary across N samples.
+ */
+final readonly class OpResult
+{
+    public function __construct(
+        public int   $medianNs,
+        public int   $minNs,
+        public int   $maxNs,
+        public float $opsPerSec,
+        public float $nsPerPayload,
+    ) {
+    }
+
+    /**
+     * @param list<int> $samplesNs Per-sample wall-clock duration in nanoseconds.
+     */
+    public static function fromSamples(
+        array $samplesNs,
+        int $payloadCount
+    ): self {
+        sort($samplesNs);
+        $count = count($samplesNs);
+        $median = $samplesNs[intdiv($count, 2)];
+
+        return new self(
+            medianNs: $median,
+            minNs: $samplesNs[0],
+            maxNs: $samplesNs[$count - 1],
+            opsPerSec: $median > 0 ? 1_000_000_000.0 / $median : 0.0,
+            nsPerPayload: $payloadCount > 0 ? $median / $payloadCount : 0.0,
+        );
+    }
+
+    /**
+     * @return array{median_ns: int, min_ns: int, max_ns: int, ops_per_sec: float, ns_per_payload: float}
+     */
+    public function toArray(): array
+    {
+        return [
+            'median_ns' => $this->medianNs,
+            'min_ns' => $this->minNs,
+            'max_ns' => $this->maxNs,
+            'ops_per_sec' => $this->opsPerSec,
+            'ns_per_payload' => $this->nsPerPayload,
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $raw
+     */
+    public static function fromArray(array $raw): self
+    {
+        return new self(
+            medianNs: Cast::toInt($raw['median_ns'] ?? 0),
+            minNs: Cast::toInt($raw['min_ns'] ?? 0),
+            maxNs: Cast::toInt($raw['max_ns'] ?? 0),
+            opsPerSec: Cast::toFloat($raw['ops_per_sec'] ?? 0.0),
+            nsPerPayload: Cast::toFloat($raw['ns_per_payload'] ?? 0.0),
+        );
+    }
+}

--- a/tests/performance/Report/Report.php
+++ b/tests/performance/Report/Report.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx ASN1 package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Performance\FreeDSx\Asn1\Report;
+
+use InvalidArgumentException;
+use RuntimeException;
+
+/**
+ * One bench run's full output: meta block + per-workload results.
+ */
+final readonly class Report
+{
+    /**
+     * @param array<string, mixed> $meta
+     * @param array<string, WorkloadResult> $workloads
+     */
+    public function __construct(
+        public array $meta,
+        public array $workloads,
+    ) {
+    }
+
+    public function toJson(): string
+    {
+        $payload = [
+            'meta' => $this->meta,
+            'workloads' => array_map(static fn (WorkloadResult $w): array => $w->toArray(), $this->workloads),
+        ];
+
+        $json = json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+        if ($json === false) {
+            throw new RuntimeException('Failed to encode bench report as JSON.');
+        }
+
+        return $json . "\n";
+    }
+
+    public function writeTo(string $path): void
+    {
+        if (file_put_contents($path, $this->toJson()) === false) {
+            throw new RuntimeException("Failed to write bench report to: $path");
+        }
+    }
+
+    public static function fromFile(string $path): self
+    {
+        if (!is_file($path)) {
+            throw new InvalidArgumentException("Report not found: $path");
+        }
+        $raw = file_get_contents($path);
+        if ($raw === false) {
+            throw new RuntimeException("Failed to read report: $path");
+        }
+        $data = json_decode($raw, true);
+        if (!is_array($data) || !isset($data['workloads']) || !is_array($data['workloads'])) {
+            throw new InvalidArgumentException("Malformed report (missing 'workloads' object): $path");
+        }
+
+        $rawMeta = is_array($data['meta'] ?? null) ? $data['meta'] : [];
+        /** @var array<string, mixed> $meta */
+        $meta = [];
+        foreach ($rawMeta as $key => $value) {
+            if (is_string($key)) {
+                $meta[$key] = $value;
+            }
+        }
+
+        $workloads = [];
+        foreach ($data['workloads'] as $name => $entry) {
+            if (!is_string($name) || !is_array($entry)) {
+                continue;
+            }
+            /** @var array<string, mixed> $stringKeyed */
+            $stringKeyed = [];
+            foreach ($entry as $k => $v) {
+                if (is_string($k)) {
+                    $stringKeyed[$k] = $v;
+                }
+            }
+            $workloads[$name] = WorkloadResult::fromArray($stringKeyed);
+        }
+
+        return new self(
+            meta: $meta,
+            workloads: $workloads,
+        );
+    }
+}

--- a/tests/performance/Report/WorkloadResult.php
+++ b/tests/performance/Report/WorkloadResult.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx ASN1 package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Performance\FreeDSx\Asn1\Report;
+
+use InvalidArgumentException;
+use Tests\Performance\FreeDSx\Asn1\Support\Cast;
+
+/**
+ * Bench results for one workload (encode + decode + round_trip).
+ */
+final readonly class WorkloadResult
+{
+    public function __construct(
+        public int      $payloads,
+        public int      $encodedBytes,
+        public OpResult $encode,
+        public OpResult $decode,
+        public OpResult $roundTrip,
+    ) {
+    }
+
+    /**
+     * @return array{payloads: int, encoded_bytes: int, encode: array<string, mixed>, decode: array<string, mixed>, round_trip: array<string, mixed>}
+     */
+    public function toArray(): array
+    {
+        return [
+            'payloads' => $this->payloads,
+            'encoded_bytes' => $this->encodedBytes,
+            'encode' => $this->encode->toArray(),
+            'decode' => $this->decode->toArray(),
+            'round_trip' => $this->roundTrip->toArray(),
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $raw
+     */
+    public static function fromArray(array $raw): self
+    {
+        return new self(
+            payloads: Cast::toInt($raw['payloads'] ?? 0),
+            encodedBytes: Cast::toInt($raw['encoded_bytes'] ?? 0),
+            encode: OpResult::fromArray(self::stringKeyedArray($raw['encode'] ?? null)),
+            decode: OpResult::fromArray(self::stringKeyedArray($raw['decode'] ?? null)),
+            roundTrip: OpResult::fromArray(self::stringKeyedArray($raw['round_trip'] ?? null)),
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private static function stringKeyedArray(mixed $value): array
+    {
+        if (!is_array($value)) {
+            return [];
+        }
+        $out = [];
+        foreach ($value as $key => $entry) {
+            if (is_string($key)) {
+                $out[$key] = $entry;
+            }
+        }
+
+        return $out;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public static function operations(): array
+    {
+        return ['encode', 'decode', 'round_trip'];
+    }
+
+    public function op(string $name): OpResult
+    {
+        return match ($name) {
+            'encode' => $this->encode,
+            'decode' => $this->decode,
+            'round_trip' => $this->roundTrip,
+            default => throw new InvalidArgumentException("Unknown operation: $name"),
+        };
+    }
+}

--- a/tests/performance/Support/Cast.php
+++ b/tests/performance/Support/Cast.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx ASN1 package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Performance\FreeDSx\Asn1\Support;
+
+use InvalidArgumentException;
+
+/**
+ * Narrowing helpers for `mixed` values from Symfony Console option parsing
+ * and JSON decoding. Centralized so we type-check once and the call sites stay clean.
+ */
+final class Cast
+{
+    public static function toInt(mixed $value, int $default = 0): int
+    {
+        if ($value === null || $value === '') {
+            return $default;
+        }
+        if (!is_numeric($value)) {
+            throw new InvalidArgumentException(sprintf(
+                'Expected numeric, got %s.',
+                get_debug_type($value),
+            ));
+        }
+
+        return (int) $value;
+    }
+
+    public static function toFloat(mixed $value, float $default = 0.0): float
+    {
+        if ($value === null || $value === '') {
+            return $default;
+        }
+        if (!is_numeric($value)) {
+            throw new InvalidArgumentException(sprintf(
+                'Expected numeric, got %s.',
+                get_debug_type($value),
+            ));
+        }
+
+        return (float) $value;
+    }
+
+    public static function toBool(mixed $value): bool
+    {
+        return (bool) $value;
+    }
+
+    public static function toString(mixed $value, string $default = ''): string
+    {
+        if ($value === null) {
+            return $default;
+        }
+        if (is_string($value)) {
+            return $value;
+        }
+        if (is_scalar($value)) {
+            return (string) $value;
+        }
+        throw new InvalidArgumentException(sprintf(
+            'Expected scalar, got %s.',
+            get_debug_type($value),
+        ));
+    }
+
+    public static function toStringOrNull(mixed $value): ?string
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        return self::toString($value);
+    }
+
+    /**
+     * @return list<string>
+     */
+    public static function toStringList(mixed $value): array
+    {
+        if (!is_array($value)) {
+            return [];
+        }
+        $out = [];
+        foreach ($value as $entry) {
+            if (is_string($entry) && $entry !== '') {
+                $out[] = $entry;
+            }
+        }
+
+        return $out;
+    }
+}

--- a/tests/performance/Workload.php
+++ b/tests/performance/Workload.php
@@ -1,0 +1,228 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx ASN1 package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Performance\FreeDSx\Asn1;
+
+use FreeDSx\Asn1\Asn1;
+use FreeDSx\Asn1\Type\AbstractType;
+
+/**
+ * Deterministic corpus generator for encoder benchmarks.
+ *
+ * Each workload returns a list of AbstractType payloads representative of a
+ * specific shape we want to measure. The RNG is seeded so two bench runs see
+ * identical input.
+ */
+final class Workload
+{
+    private const SEED = 0x4153_4e31;
+
+    /**
+     * @return array<string, list<AbstractType<mixed>>>
+     */
+    public static function all(): array
+    {
+        return [
+            'ldap_search_entry' => self::ldapSearchEntries(200),
+            'string_heavy' => self::stringHeavy(500),
+            'oid_heavy' => self::oidHeavy(500),
+            'integer_heavy' => self::integerHeavy(2000),
+            'mixed_message' => self::mixedMessages(100),
+            'primitives_baseline' => self::primitivesBaseline(2000),
+        ];
+    }
+
+    /**
+     * LDAP-shaped: each entry is Sequence(OctetString DN, Sequence(Sequence(OctetString attr, Set(OctetString[]))×5))
+     *
+     * @return list<AbstractType<mixed>>
+     */
+    private static function ldapSearchEntries(int $count): array
+    {
+        $rng = self::rng();
+        $entries = [];
+        for ($i = 0; $i < $count; $i++) {
+            $attrs = [];
+            for ($a = 0; $a < 5; $a++) {
+                $values = [];
+                for ($v = 0; $v < 3; $v++) {
+                    $values[] = Asn1::octetString(self::randomString($rng, 16, 64));
+                }
+                $attrs[] = Asn1::sequence(
+                    Asn1::octetString('attr-' . self::randomString($rng, 4, 12)),
+                    Asn1::setOf(...$values),
+                );
+            }
+            $entries[] = Asn1::sequence(
+                Asn1::octetString('cn=user' . $i . ',dc=example,dc=org'),
+                Asn1::sequence(...$attrs),
+            );
+        }
+
+        return $entries;
+    }
+
+    /**
+     * Sequence of long octet strings — stresses AbstractStringType constructor and length encoding.
+     *
+     * @return list<AbstractType<mixed>>
+     */
+    private static function stringHeavy(int $count): array
+    {
+        $rng = self::rng();
+        $items = [];
+        for ($i = 0; $i < $count; $i++) {
+            $items[] = Asn1::sequence(
+                Asn1::octetString(self::randomString($rng, 64, 256)),
+                Asn1::utf8String(self::randomString($rng, 8, 32)),
+                Asn1::printableString(self::randomString($rng, 8, 32)),
+                Asn1::ia5String(self::randomString($rng, 8, 32)),
+            );
+        }
+
+        return $items;
+    }
+
+    /**
+     * Sequences of OIDs — stresses OidType encoding.
+     *
+     * @return list<AbstractType<mixed>>
+     */
+    private static function oidHeavy(int $count): array
+    {
+        $rng = self::rng();
+        $oids = [
+            '1.3.6.1.4.1.1466.20037',
+            '1.3.6.1.4.1.4203.1.5.1',
+            '2.5.4.3',
+            '2.5.4.4',
+            '1.2.840.113549.1.1.11',
+            '1.3.6.1.4.1.311.21.20',
+            '1.2.840.113549',
+            '0.9.2342.19200300.100.1.1',
+        ];
+        $items = [];
+        for ($i = 0; $i < $count; $i++) {
+            $children = [];
+            for ($k = 0; $k < 6; $k++) {
+                $children[] = Asn1::oid($oids[$rng() % count($oids)]);
+            }
+            $items[] = Asn1::sequenceOf(...$children);
+        }
+
+        return $items;
+    }
+
+    /**
+     * Many integer + enumerated values — exercises the integer encoding path.
+     *
+     * @return list<AbstractType<mixed>>
+     */
+    private static function integerHeavy(int $count): array
+    {
+        $rng = self::rng();
+        $items = [];
+        for ($i = 0; $i < $count; $i++) {
+            $items[] = Asn1::sequence(
+                Asn1::integer(($rng() % 200000) - 100000),
+                Asn1::integer($rng() % 1000),
+                Asn1::enumerated($rng() % 16),
+                Asn1::boolean(($rng() & 1) === 1),
+            );
+        }
+
+        return $items;
+    }
+
+    /**
+     * Approximate LDAPMessage envelope wrapping a SearchResultEntry payload.
+     *
+     * @return list<AbstractType<mixed>>
+     */
+    private static function mixedMessages(int $count): array
+    {
+        $rng = self::rng();
+        $messages = [];
+        for ($i = 0; $i < $count; $i++) {
+            $attrs = [];
+            for ($a = 0; $a < 8; $a++) {
+                $values = [];
+                for ($v = 0; $v < 2; $v++) {
+                    $values[] = Asn1::octetString(self::randomString($rng, 8, 48));
+                }
+                $attrs[] = Asn1::sequence(
+                    Asn1::octetString('attr-' . self::randomString($rng, 4, 10)),
+                    Asn1::setOf(...$values),
+                );
+            }
+            $payload = Asn1::application(4, Asn1::sequence(
+                Asn1::octetString('cn=u' . $i . ',ou=people,dc=example,dc=org'),
+                Asn1::sequence(...$attrs),
+            ));
+            $messages[] = Asn1::sequence(
+                Asn1::integer($i + 1),
+                $payload,
+            );
+        }
+
+        return $messages;
+    }
+
+    /**
+     * Synthetic small primitives — isolates per-type overhead from collection effects.
+     *
+     * @return list<AbstractType<mixed>>
+     */
+    private static function primitivesBaseline(int $count): array
+    {
+        $items = [];
+        for ($i = 0; $i < $count; $i++) {
+            $items[] = match ($i & 0x3) {
+                0 => Asn1::boolean(($i & 1) === 1),
+                1 => Asn1::integer($i),
+                2 => Asn1::null(),
+                default => Asn1::octetString('x' . $i),
+            };
+        }
+
+        return $items;
+    }
+
+    /**
+     * Returns a deterministic mt_rand-style closure.
+     *
+     * @return callable(): int
+     */
+    private static function rng(): callable
+    {
+        mt_srand(self::SEED);
+
+        return static fn (): int => mt_rand();
+    }
+
+    /**
+     * @param callable(): int $rng
+     */
+    private static function randomString(callable $rng, int $minLen, int $maxLen): string
+    {
+        $len = $minLen + ($rng() % max(1, ($maxLen - $minLen + 1)));
+        $alphabet = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_.';
+        $alphaLen = strlen($alphabet);
+        $out = '';
+        for ($i = 0; $i < $len; $i++) {
+            $out .= $alphabet[$rng() % $alphaLen];
+        }
+
+        return $out;
+    }
+}

--- a/tests/performance/baseline-floor.json
+++ b/tests/performance/baseline-floor.json
@@ -1,0 +1,36 @@
+{
+    "meta": {
+        "captured_on": "2026-04-26",
+        "runner": "ubuntu-latest",
+        "php": "8.5",
+        "margin_pct": 20,
+        "note": "Captured from a GitHub Actions ubuntu-latest perf run. Each value = measured ns/payload * 1.20 (rounded up). Refresh via `composer bench-update-floor` after intentional perf changes or runner-generation upgrades."
+    },
+    "floor_ns_per_payload": {
+        "ldap_search_entry": {
+            "encode": 17660,
+            "decode": 12075,
+            "round_trip": 30578
+        },
+        "string_heavy": {
+            "encode": 2664,
+            "decode": 2492,
+            "round_trip": 5643
+        },
+        "oid_heavy": {
+            "encode": 9826,
+            "decode": 6677,
+            "round_trip": 17037
+        },
+        "integer_heavy": {
+            "encode": 2378,
+            "decode": 1948,
+            "round_trip": 4704
+        },
+        "mixed_message": {
+            "encode": 23906,
+            "decode": 15995,
+            "round_trip": 41120
+        }
+    }
+}

--- a/tests/unit/Encoder/BerEncoderTest.php
+++ b/tests/unit/Encoder/BerEncoderTest.php
@@ -16,6 +16,7 @@ namespace Tests\Unit\FreeDSx\Asn1\Encoder;
 use DateTime;
 use DateTimeZone;
 use FreeDSx\Asn1\Encoder\BerEncoder;
+use FreeDSx\Asn1\Encoder\EncoderOptions;
 use FreeDSx\Asn1\Exception\EncoderException;
 use FreeDSx\Asn1\Exception\PartialPduException;
 use FreeDSx\Asn1\Type\AbstractType;
@@ -57,10 +58,12 @@ final class BerEncoderTest extends TestCase
 
     public function test_it_should_set_options(): void
     {
-        $this->subject->setOptions(['bitstring_padding' => '1']);
+        $options = new EncoderOptions(bitstringPadding: '1');
+
+        $this->subject->setOptions($options);
 
         self::assertSame(
-            ['bitstring_padding' => '1'],
+            $options,
             $this->subject->getOptions(),
         );
     }
@@ -68,8 +71,18 @@ final class BerEncoderTest extends TestCase
     public function test_it_should_get_options(): void
     {
         self::assertSame(
-            ['bitstring_padding' => '0'],
-            $this->subject->getOptions(),
+            '0',
+            $this->subject->getOptions()->bitstringPadding,
+        );
+    }
+
+    public function test_it_should_accept_options_via_the_constructor(): void
+    {
+        $subject = new BerEncoder(new EncoderOptions(bitstringPadding: '1'));
+
+        self::assertSame(
+            '1',
+            $subject->getOptions()->bitstringPadding,
         );
     }
 

--- a/tests/unit/Type/NullTypeTest.php
+++ b/tests/unit/Type/NullTypeTest.php
@@ -26,11 +26,6 @@ final class NullTypeTest extends TestCase
         $this->subject = new NullType();
     }
 
-    public function test_it_should_have_a_null_value(): void
-    {
-        self::assertNull($this->subject->getValue());
-    }
-
     public function test_it_should_have_a_default_tag_type(): void
     {
         self::assertSame(


### PR DESCRIPTION
As I make some updates to this library, I need a way to measure performance to make sure it doesn't regress. As this is basically the heart of the LDAP library and tons of data will pass through it on searches. The performance scripts are just quick and dirty generated stuff. But I want to use it to judge future changes so want it in place. It's jammed in the test directory area.