### PR TITLE
Add an attribute encoding helper.

### DIFF
--- a/src/FreeDSx/Asn1/Asn1.php
+++ b/src/FreeDSx/Asn1/Asn1.php
@@ -28,6 +28,7 @@ use FreeDSx\Asn1\Type\NumericStringType;
 use FreeDSx\Asn1\Type\OctetStringType;
 use FreeDSx\Asn1\Type\OidType;
 use FreeDSx\Asn1\Type\PrintableStringType;
+use FreeDSx\Asn1\Type\RawType;
 use FreeDSx\Asn1\Type\RealType;
 use FreeDSx\Asn1\Type\RelativeOidType;
 use FreeDSx\Asn1\Type\SequenceOfType;
@@ -115,6 +116,17 @@ class Asn1
     public static function octetString(string $string): OctetStringType
     {
         return new OctetStringType($string);
+    }
+
+    /**
+     * A pre-encoded element emitted verbatim by the encoder (tag, length, and content already included).
+     *
+     * @param string $value
+     * @return RawType
+     */
+    public static function raw(string $value): RawType
+    {
+        return new RawType($value);
     }
 
     /**

--- a/src/FreeDSx/Asn1/Encoder/BerEncoder.php
+++ b/src/FreeDSx/Asn1/Encoder/BerEncoder.php
@@ -35,6 +35,7 @@ use FreeDSx\Asn1\Type\NumericStringType;
 use FreeDSx\Asn1\Type\OctetStringType;
 use FreeDSx\Asn1\Type\OidType;
 use FreeDSx\Asn1\Type\PrintableStringType;
+use FreeDSx\Asn1\Type\RawType;
 use FreeDSx\Asn1\Type\RealType;
 use FreeDSx\Asn1\Type\RelativeOidType;
 use FreeDSx\Asn1\Type\SequenceOfType;
@@ -92,6 +93,8 @@ use function substr;
  */
 class BerEncoder implements EncoderInterface
 {
+    use LengthEncodingTrait;
+
     /**
      * Used to represent a bool false binary string.
      */
@@ -224,6 +227,11 @@ class BerEncoder implements EncoderInterface
      */
     public function encode(AbstractType $type): string
     {
+        # A raw type is already fully encoded (tag, length, and content); emit it verbatim.
+        if ($type::class === RawType::class) {
+            return $type->getValue();
+        }
+
         # match($type::class) compiles to JMP_TABLE — O(1), so this is strictly for performance.
         $tagNumber = $type->getTagNumber();
         $isConstructed = $type->getIsConstructed();
@@ -701,21 +709,6 @@ class BerEncoder implements EncoderInterface
      * @return string
      * @throws EncoderException
      */
-    protected function encodeLongDefiniteLength(int $num)
-    {
-        $bytes = '';
-        while ($num) {
-            $bytes = (chr((int) ($num % 256))) . $bytes;
-            $num = (int) ($num / 256);
-        }
-
-        $length = strlen($bytes);
-        if ($length >= 127) {
-            throw new EncoderException('The encoded length cannot be greater than or equal to 127 bytes');
-        }
-
-        return chr(0x80 | $length) . $bytes;
-    }
 
     /**
      * @param BitStringType $type

--- a/src/FreeDSx/Asn1/Encoder/LengthEncodingTrait.php
+++ b/src/FreeDSx/Asn1/Encoder/LengthEncodingTrait.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * This file is part of the FreeDSx ASN1 package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Asn1\Encoder;
+
+use FreeDSx\Asn1\Exception\EncoderException;
+
+/**
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+trait LengthEncodingTrait
+{
+    /**
+     * Long-form definite-length octet encoding, shared by BER-based encoders.
+     *
+     * @throws EncoderException
+     */
+    protected function encodeLongDefiniteLength(int $num): string
+    {
+        $bytes = '';
+        while ($num) {
+            $bytes = (chr((int) ($num % 256))) . $bytes;
+            $num = (int) ($num / 256);
+        }
+
+        $length = strlen($bytes);
+        if ($length >= 127) {
+            throw new EncoderException('The encoded length cannot be greater than or equal to 127 bytes');
+        }
+
+        return chr(0x80 | $length) . $bytes;
+    }
+}

--- a/src/FreeDSx/Asn1/Helper/AttributeEntryEncoder.php
+++ b/src/FreeDSx/Asn1/Helper/AttributeEntryEncoder.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx ASN1 package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Asn1\Helper;
+
+use FreeDSx\Asn1\Encoder\LengthEncodingTrait;
+use FreeDSx\Asn1\Exception\EncoderException;
+use FreeDSx\Asn1\Type\AbstractType;
+
+use function chr;
+use function sprintf;
+use function strlen;
+
+/**
+ * A dedicated BER encoder for optimizing attribute encoding in LDAP. The object graph of this library can be slow on
+ * encoding when there are a lot of objects involved. This exists as a performance optimization in this library to keep
+ * the ASN1 logic here, and this is genuinely needed to improve encoding speed on common search operations.
+ *
+ * This is the RFC 4511 SearchResultEntry / AddRequest AttributeList body.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final class AttributeEntryEncoder
+{
+    use LengthEncodingTrait;
+
+    private const OCTET_STRING = "\x04";
+
+    private const SEQUENCE = "\x30";
+
+    private const SET_OF = "\x31";
+
+    /**
+     * Encodes the tagged attribute entry to definite-length BER, byte-identical to encoding the equivalent type graph.
+     *
+     * The normal length encoding is deliberately inline for performance reasons.
+     *
+     * @param int $appTag The application tag number (e.g. the SearchResultEntry tag).
+     * @param string $primaryId The leading octet string (e.g. the entry DN).
+     * @param iterable<array{0: string, 1: array<string>}> $attributes Each entry is [description, values].
+     * @throws EncoderException
+     */
+    public function encode(
+        int $appTag,
+        string $primaryId,
+        iterable $attributes,
+    ): string {
+        $attributeList = '';
+
+        foreach ($attributes as [$description, $values]) {
+            $set = '';
+            foreach ($values as $value) {
+                $length = strlen($value);
+                $set .= self::OCTET_STRING . ($length < 128 ? chr($length) : $this->encodeLongDefiniteLength($length)) . $value;
+            }
+
+            $descriptionLength = strlen($description);
+            $setLength = strlen($set);
+            $attribute = self::OCTET_STRING
+                . ($descriptionLength < 128 ? chr($descriptionLength) : $this->encodeLongDefiniteLength($descriptionLength))
+                . $description
+                . self::SET_OF
+                . ($setLength < 128 ? chr($setLength) : $this->encodeLongDefiniteLength($setLength))
+                . $set;
+
+            $attributeLength = strlen($attribute);
+            $attributeList .= self::SEQUENCE
+                . ($attributeLength < 128 ? chr($attributeLength) : $this->encodeLongDefiniteLength($attributeLength))
+                . $attribute;
+        }
+
+        $primaryIdLength = strlen($primaryId);
+        $attributeListLength = strlen($attributeList);
+        $body = self::OCTET_STRING
+            . ($primaryIdLength < 128 ? chr($primaryIdLength) : $this->encodeLongDefiniteLength($primaryIdLength))
+            . $primaryId
+            . self::SEQUENCE
+            . ($attributeListLength < 128 ? chr($attributeListLength) : $this->encodeLongDefiniteLength($attributeListLength))
+            . $attributeList;
+
+        $bodyLength = strlen($body);
+
+        return $this->applicationTag($appTag)
+            . ($bodyLength < 128 ? chr($bodyLength) : $this->encodeLongDefiniteLength($bodyLength))
+            . $body;
+    }
+
+    /**
+     * @throws EncoderException
+     */
+    private function applicationTag(int $appTag): string
+    {
+        # Application class (0x40) + constructed (0x20). The high-tag form is not needed for LDAP PDUs.
+        if ($appTag < 0 || $appTag >= 31) {
+            throw new EncoderException(sprintf(
+                'The application tag "%d" is not supported by the fast-path encoder.',
+                $appTag,
+            ));
+        }
+
+        return chr(AbstractType::TAG_CLASS_APPLICATION | AbstractType::CONSTRUCTED_TYPE | $appTag);
+    }
+}

--- a/src/FreeDSx/Asn1/Type/RawType.php
+++ b/src/FreeDSx/Asn1/Type/RawType.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx ASN1 package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Asn1\Type;
+
+/**
+ * A fully pre-encoded ASN1 element. The encoder emits its value verbatim (tag, length, and content already included).
+ *
+ * @extends AbstractType<string>
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final class RawType extends AbstractType
+{
+    public function __construct(string $value)
+    {
+        parent::__construct($value);
+    }
+
+    public function getValue(): string
+    {
+        return $this->value;
+    }
+}

--- a/tests/unit/Asn1Test.php
+++ b/tests/unit/Asn1Test.php
@@ -31,6 +31,7 @@ use FreeDSx\Asn1\Type\NumericStringType;
 use FreeDSx\Asn1\Type\OctetStringType;
 use FreeDSx\Asn1\Type\OidType;
 use FreeDSx\Asn1\Type\PrintableStringType;
+use FreeDSx\Asn1\Type\RawType;
 use FreeDSx\Asn1\Type\RealType;
 use FreeDSx\Asn1\Type\RelativeOidType;
 use FreeDSx\Asn1\Type\SequenceOfType;
@@ -148,6 +149,14 @@ final class Asn1Test extends TestCase
         self::assertEquals(
             new OctetStringType('foo'),
             Asn1::octetString('foo'),
+        );
+    }
+
+    public function test_it_should_construct_a_raw_type(): void
+    {
+        self::assertEquals(
+            new RawType("\x04\x03abc"),
+            Asn1::raw("\x04\x03abc"),
         );
     }
 

--- a/tests/unit/Encoder/BerEncoderTest.php
+++ b/tests/unit/Encoder/BerEncoderTest.php
@@ -37,6 +37,7 @@ use FreeDSx\Asn1\Type\NumericStringType;
 use FreeDSx\Asn1\Type\OctetStringType;
 use FreeDSx\Asn1\Type\OidType;
 use FreeDSx\Asn1\Type\PrintableStringType;
+use FreeDSx\Asn1\Type\RawType;
 use FreeDSx\Asn1\Type\RealType;
 use FreeDSx\Asn1\Type\RelativeOidType;
 use FreeDSx\Asn1\Type\SequenceType;
@@ -1721,5 +1722,26 @@ final class BerEncoderTest extends TestCase
         $this->expectException(EncoderException::class);
 
         $this->subject->encode((new IntegerType(1))->setTagNumber('foo'));
+    }
+
+    public function test_it_should_emit_a_raw_type_verbatim(): void
+    {
+        $preEncoded = $this->subject->encode(new OctetStringType('hello'));
+
+        self::assertSame(
+            $preEncoded,
+            $this->subject->encode(new RawType($preEncoded)),
+        );
+    }
+
+    public function test_it_should_encode_a_spliced_raw_type_identically_to_the_equivalent_type(): void
+    {
+        $octet = new OctetStringType('hello');
+        $preEncoded = $this->subject->encode($octet);
+
+        self::assertSame(
+            $this->subject->encode(new SequenceType(new IntegerType(7), $octet)),
+            $this->subject->encode(new SequenceType(new IntegerType(7), new RawType($preEncoded))),
+        );
     }
 }

--- a/tests/unit/Helper/AttributeEntryEncoderTest.php
+++ b/tests/unit/Helper/AttributeEntryEncoderTest.php
@@ -1,0 +1,163 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx ASN1 package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Asn1\Helper;
+
+use FreeDSx\Asn1\Asn1;
+use FreeDSx\Asn1\Encoder\BerEncoder;
+use FreeDSx\Asn1\Exception\EncoderException;
+use FreeDSx\Asn1\Helper\AttributeEntryEncoder;
+use FreeDSx\Asn1\Type\AbstractType;
+use FreeDSx\Asn1\Type\OctetStringType;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class AttributeEntryEncoderTest extends TestCase
+{
+    private const APP_TAG = 4;
+
+    private AttributeEntryEncoder $subject;
+
+    private BerEncoder $encoder;
+
+    protected function setUp(): void
+    {
+        $this->subject = new AttributeEntryEncoder();
+        $this->encoder = new BerEncoder();
+    }
+
+    public function test_it_encodes_a_typical_entry_identically(): void
+    {
+        $this->assertEncodesIdentically(
+            'cn=seed-1,dc=foo,dc=bar',
+            [
+                ['cn', ['seed-1']],
+                ['objectClass', ['inetOrgPerson', 'extensibleObject']],
+                ['sn', ['Seeded']],
+                ['mail', ['seed-1@foo.bar']],
+                ['uidNumber', ['1001']],
+            ],
+        );
+    }
+
+    public function test_it_encodes_an_entry_with_no_attributes_identically(): void
+    {
+        $this->assertEncodesIdentically(
+            'dc=foo,dc=bar',
+            [],
+        );
+    }
+
+    public function test_it_encodes_an_attribute_with_no_values_identically(): void
+    {
+        $this->assertEncodesIdentically(
+            'cn=empty,dc=foo,dc=bar',
+            [['cn', []]],
+        );
+    }
+
+    public function test_it_encodes_multivalued_and_unicode_values_identically(): void
+    {
+        $this->assertEncodesIdentically(
+            'cn=Iván,dc=foo,dc=bar',
+            [
+                ['member', ['cn=a,dc=foo', 'cn=b,dc=foo', 'cn=c,dc=foo']],
+                ['displayName', ['Iván Ñoño 東京']],
+                ['userCertificate;binary', ["\x00\x01\x02\xff"]],
+            ],
+        );
+    }
+
+    public function test_it_encodes_many_small_attributes_forcing_long_form_containers_identically(): void
+    {
+        $attributes = [];
+        for ($i = 0; $i < 60; $i++) {
+            $attributes[] = ["attr-{$i}", ["value-{$i}"]];
+        }
+
+        $this->assertEncodesIdentically(
+            'cn=wide,dc=foo,dc=bar',
+            $attributes,
+        );
+    }
+
+    #[DataProvider('lengthBoundaryProvider')]
+    public function test_it_encodes_values_across_length_boundaries_identically(int $length): void
+    {
+        $this->assertEncodesIdentically(
+            'cn=boundary,dc=foo,dc=bar',
+            [
+                [str_repeat('d', $length), [str_repeat('v', $length)]],
+            ],
+        );
+    }
+
+    /**
+     * @return array<string, array{int}>
+     */
+    public static function lengthBoundaryProvider(): array
+    {
+        return [
+            '127 (short form max)' => [127],
+            '128 (long form min)' => [128],
+            '255 (one length octet max)' => [255],
+            '256 (two length octets)' => [256],
+            '65535 (two length octets max)' => [65535],
+            '65536 (three length octets)' => [65536],
+        ];
+    }
+
+    public function test_it_rejects_an_unsupported_high_application_tag(): void
+    {
+        $this->expectException(EncoderException::class);
+
+        $this->subject->encode(31, 'cn=x', []);
+    }
+
+    /**
+     * @param list<array{0: string, 1: list<string>}> $attributes
+     */
+    private function assertEncodesIdentically(string $primaryId, array $attributes): void
+    {
+        self::assertSame(
+            $this->encoder->encode($this->buildGraph(self::APP_TAG, $primaryId, $attributes)),
+            $this->subject->encode(self::APP_TAG, $primaryId, $attributes),
+        );
+    }
+
+    /**
+     * Builds the equivalent type graph the dedicated encoder must match byte-for-byte.
+     *
+     * @param list<array{0: string, 1: list<string>}> $attributes
+     * @return AbstractType<mixed>
+     */
+    private function buildGraph(int $appTag, string $primaryId, array $attributes): AbstractType
+    {
+        $partialAttributes = Asn1::sequenceOf();
+        foreach ($attributes as [$description, $values]) {
+            $valueTypes = array_map(
+                static fn (string $value): OctetStringType => Asn1::octetString($value),
+                $values,
+            );
+            $partialAttributes->addChild(Asn1::sequence(
+                Asn1::octetString($description),
+                Asn1::setOf(...$valueTypes),
+            ));
+        }
+
+        return Asn1::application($appTag, Asn1::sequence(
+            Asn1::octetString($primaryId),
+            $partialAttributes,
+        ));
+    }
+}


### PR DESCRIPTION
This is a tradeoff to keep ASN1 logic in this library, but provide a fast-path helper for LDAP. The performance gains of doing this are enough to warrant it. Attribute encoding on searches is very CPU intensive and this helps for large searches / lots of entries / lots of attributes. This will be used in the LDAP library as a way to optimize server side entry attribute encoding. I've already benchmarked the changes on the LDAP side and it's a roughly 40% encoding savings on searches.